### PR TITLE
Initial GitHub Actions CI configuration

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -1,0 +1,28 @@
+name: Premerge
+
+on:
+  pull_request:
+    types: [opened, synchronized, reopened]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Build check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -3,6 +3,10 @@ name: Premerge
 on:
   pull_request:
     types: [opened, synchronized, reopened]
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: 0 0 1 * *
 
 jobs:
   build-and-test:

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2020-09-27
           override: true
 
       - name: Build check

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -30,3 +30,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  linting:
+    if: ${{ github.ref != 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2020-09-27
+          default: true
+          components: rustfmt, clippy
+
+      - name: format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -55,3 +55,4 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -2,9 +2,9 @@ name: Premerge
 
 on:
   pull_request:
-    types: [opened, synchronized, reopened]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: 0 0 1 * *
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: rust
-rust: nightly
-cache: cargo

--- a/libs/badge/badge.rs
+++ b/libs/badge/badge.rs
@@ -4,8 +4,7 @@ use base64::display::Base64Display;
 use once_cell::sync::Lazy;
 use rusttype::{point, Font, Point, PositionedGlyph, Scale};
 
-const FONT_DATA: &'static [u8] =
-    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/DejaVuSans.ttf"));
+const FONT_DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/DejaVuSans.ttf"));
 const FONT_SIZE: f32 = 11.;
 const SCALE: Scale = Scale {
     x: FONT_SIZE,
@@ -45,7 +44,7 @@ static DATA: Lazy<BadgeStaticData> = Lazy::new(|| {
 
     BadgeStaticData {
         font,
-        scale: SCALE.clone(),
+        scale: SCALE,
         offset,
     }
 });


### PR DESCRIPTION
This PR adds the initial CI configuration for the build, test, and lint cycle.

- Scheduled builds on `main` (except linting)
- Clippy lints reported as annotations ([example](https://github.com/deps-rs/deps.rs/pull/49/checks?check_run_id=1205495976)).

Future PRs can introduce: 

- Build caching to speed up builds (using https://github.com/actions/cache, taking care with nightly toolchains).
- Test coverage collection and reporting
- `cargo audit` runs to collect and report security vulnerabilities