### PR TITLE
Add User-Agent to all requests

### DIFF
--- a/src/interactors/crates.rs
+++ b/src/interactors/crates.rs
@@ -2,7 +2,7 @@ use std::str;
 
 use anyhow::{anyhow, ensure, Error};
 use futures::{future, Future, IntoFuture, Stream};
-use hyper::{Body, Error as HyperError, Method, Request, Response, Uri};
+use hyper::{Body, Error as HyperError, Method, Request, Response, Uri, header::USER_AGENT};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use tokio_service::Service;
@@ -97,7 +97,9 @@ where
         let uri =
             try_future_box!(format!("{}/master/{}", CRATES_INDEX_BASE_URI, path).parse::<Uri>());
 
-        let request = Request::get(uri.clone()).body(Body::empty()).unwrap();
+        let request = Request::get(uri.clone())
+            .header(USER_AGENT, "deps.rs")
+            .body(Body::empty()).unwrap();
 
         Box::new(self.0.call(request).from_err().and_then(move |response| {
             let status = response.status();
@@ -170,7 +172,9 @@ where
         let uri = format!("{}/summary", CRATES_API_BASE_URI)
             .parse::<Uri>()
             .unwrap();
-        let request = Request::get(uri.clone()).body(Body::empty()).unwrap();
+        let request = Request::get(uri.clone())
+            .header(USER_AGENT, "deps.rs")
+            .body(Body::empty()).unwrap();
 
         Box::new(service.call(request).from_err().and_then(move |response| {
             let status = response.status();

--- a/src/interactors/mod.rs
+++ b/src/interactors/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, ensure, Error};
 use futures::{Future, Stream};
-use hyper::{Body, Error as HyperError, Method, Request, Response};
+use hyper::{Body, Error as HyperError, Method, Request, Response, header::USER_AGENT};
 use relative_path::RelativePathBuf;
 use tokio_service::Service;
 
@@ -35,7 +35,9 @@ where
             &RepoSite::Bitbucket => try_future_box!(bitbucket::get_manifest_uri(&repo_path, &path)),
         };
 
-        let request = Request::get(uri.clone()).body(Body::empty()).unwrap();
+        let request = Request::get(uri.clone())
+            .header(USER_AGENT, "deps.rs")
+            .body(Body::empty()).unwrap();
 
         Box::new(self.0.call(request).from_err().and_then(move |response| {
             let status = response.status();


### PR DESCRIPTION
Provide the `User-Agent` header in every request from the server.

This became required by crates.io, which would otherwise forbid the request.

Resolves #38.