### PR TITLE
Add support for 2018 edition crate renaming

### DIFF
--- a/src/interactors/crates.rs
+++ b/src/interactors/crates.rs
@@ -22,6 +22,8 @@ struct RegistryPackageDep {
     req: VersionReq,
     #[serde(default)]
     kind: Option<String>,
+    #[serde(default)]
+    package: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -42,13 +44,10 @@ fn convert_pkgs(
         .map(|package| {
             let mut deps = CrateDeps::default();
             for dep in package.deps {
-                match dep.kind.unwrap_or_else(|| "normal".into()).as_ref() {
-                    "normal" => deps
-                        .main
-                        .insert(dep.name.parse()?, CrateDep::External(dep.req)),
-                    "dev" => deps
-                        .dev
-                        .insert(dep.name.parse()?, CrateDep::External(dep.req)),
+                let name = dep.package.as_deref().unwrap_or(&dep.name).parse()?;
+                match dep.kind.as_deref().unwrap_or("normal") {
+                    "normal" => deps.main.insert(name, CrateDep::External(dep.req)),
+                    "dev" => deps.dev.insert(name, CrateDep::External(dep.req)),
                     _ => None,
                 };
             }


### PR DESCRIPTION
Example crates that failed before:

* http://localhost:8080/crate/lettre/0.10.0-alpha.2
* http://localhost:8080/repo/github/lettre/lettre