### PR TITLE
Remove Mutex around Cache and move away from deprecated lru-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,12 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
-
-[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,13 +675,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
+name = "lru_time_cache"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
+checksum = "53883292fdb9976d4666a9ede31ed599c255be9715947a8bd2adc72522e66749"
 
 [[package]]
 name = "matches"
@@ -1316,7 +1307,7 @@ dependencies = [
  "futures",
  "hyper",
  "indexmap",
- "lru-cache",
+ "lru_time_cache",
  "maud",
  "once_cell",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ derive_more = "0.99"
 futures = "0.3"
 hyper = "0.13"
 indexmap = { version = "1", features = ["serde-1"] }
-lru-cache = "0.1" # TODO: replace unmaintained crate
+lru_time_cache = "0.11.1"
 maud = "0.22"
 once_cell = "1.4"
 pin-project = "0.4"

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt,
-    sync::Arc,
-    time::Duration,
-};
+use std::{fmt, sync::Arc, time::Duration};
 
 use derive_more::{Display, Error, From};
 use hyper::service::Service;


### PR DESCRIPTION
This also improves our throughput, because we're not holding an exclusive lock for the entire duration of the request