### PR TITLE
Remove dev-dependencies from badge

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -100,10 +100,31 @@ impl AnalyzeDependenciesOutcome {
         self.crates.iter().any(|&(_, ref deps)| deps.any_outdated())
     }
 
+    // TODO(feliix42): Why is this different from the any_outdated() function above?
     pub fn any_insecure(&self) -> bool {
         self.crates
             .iter()
             .any(|&(_, ref deps)| deps.count_insecure() > 0)
+    }
+
+    pub fn any_dev_issues(&self) -> bool {
+        self.crates
+            .iter()
+            .any(|&(_, ref deps)| deps.any_dev_issues())
+    }
+
+    pub fn count_dev_outdated(&self) -> usize {
+        self.crates
+            .iter()
+            .map(|&(_, ref deps)| deps.count_dev_outdated())
+            .sum()
+    }
+
+    pub fn count_dev_insecure(&self) -> usize {
+        self.crates
+            .iter()
+            .map(|&(_, ref deps)| deps.count_dev_insecure())
+            .sum()
     }
 
     pub fn outdated_ratio(&self) -> (usize, usize) {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -131,7 +131,7 @@ impl AnalyzeDependenciesOutcome {
             .sum()
     }
 
-    /// Returns the number of outdated and the number of total main and build dependencies 
+    /// Returns the number of outdated and the number of total main and build dependencies
     pub fn outdated_ratio(&self) -> (usize, usize) {
         self.crates
             .iter()

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -101,18 +101,21 @@ impl AnalyzeDependenciesOutcome {
     }
 
     // TODO(feliix42): Why is this different from the any_outdated() function above?
+    /// Checks if any insecure main or build dependencies exist in the scanned crates
     pub fn any_insecure(&self) -> bool {
         self.crates
             .iter()
             .any(|&(_, ref deps)| deps.count_insecure() > 0)
     }
 
+    /// Checks if any dev-dependencies in the scanned crates are either outdated or insecure
     pub fn any_dev_issues(&self) -> bool {
         self.crates
             .iter()
             .any(|&(_, ref deps)| deps.any_dev_issues())
     }
 
+    /// Returns the number of outdated dev-dependencies
     pub fn count_dev_outdated(&self) -> usize {
         self.crates
             .iter()
@@ -120,6 +123,7 @@ impl AnalyzeDependenciesOutcome {
             .sum()
     }
 
+    /// Returns the number of insecure dev-dependencies
     pub fn count_dev_insecure(&self) -> usize {
         self.crates
             .iter()
@@ -127,6 +131,7 @@ impl AnalyzeDependenciesOutcome {
             .sum()
     }
 
+    /// Returns the number of outdated and the number of total main and build dependencies 
     pub fn outdated_ratio(&self) -> (usize, usize) {
         self.crates
             .iter()

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -152,10 +152,12 @@ impl AnalyzedDependencies {
         AnalyzedDependencies { main, dev, build }
     }
 
+    /// Counts the total number of main and build dependencies
     pub fn count_total(&self) -> usize {
         self.main.len() + self.build.len()
     }
 
+    /// Returns the number of outdated main and build dependencies
     pub fn count_outdated(&self) -> usize {
         let main_outdated = self
             .main
@@ -170,13 +172,14 @@ impl AnalyzedDependencies {
         main_outdated + build_outdated
     }
 
+    /// Returns the number of insecure main and build dependencies
     pub fn count_insecure(&self) -> usize {
         let main_insecure = self.main.iter().filter(|&(_, dep)| dep.insecure).count();
         let build_insecure = self.build.iter().filter(|&(_, dep)| dep.insecure).count();
         main_insecure + build_insecure
     }
 
-    /// Checks if any outdated dependencies exist
+    /// Checks if any outdated main or build dependencies exist
     pub fn any_outdated(&self) -> bool {
         let main_any_outdated = self.main.iter().any(|(_, dep)| dep.is_outdated());
         let build_any_outdated = self.build.iter().any(|(_, dep)| dep.is_outdated());

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -153,7 +153,7 @@ impl AnalyzedDependencies {
     }
 
     pub fn count_total(&self) -> usize {
-        self.main.len() + self.dev.len() + self.build.len()
+        self.main.len() + self.build.len()
     }
 
     pub fn count_outdated(&self) -> usize {
@@ -162,31 +162,45 @@ impl AnalyzedDependencies {
             .iter()
             .filter(|&(_, dep)| dep.is_outdated())
             .count();
-        let dev_outdated = self
-            .dev
-            .iter()
-            .filter(|&(_, dep)| dep.is_outdated())
-            .count();
         let build_outdated = self
             .build
             .iter()
             .filter(|&(_, dep)| dep.is_outdated())
             .count();
-        main_outdated + dev_outdated + build_outdated
+        main_outdated + build_outdated
     }
 
     pub fn count_insecure(&self) -> usize {
         let main_insecure = self.main.iter().filter(|&(_, dep)| dep.insecure).count();
-        let dev_insecure = self.dev.iter().filter(|&(_, dep)| dep.insecure).count();
         let build_insecure = self.build.iter().filter(|&(_, dep)| dep.insecure).count();
-        main_insecure + dev_insecure + build_insecure
+        main_insecure + build_insecure
     }
 
+    /// Checks if any outdated dependencies exist
     pub fn any_outdated(&self) -> bool {
         let main_any_outdated = self.main.iter().any(|(_, dep)| dep.is_outdated());
-        let dev_any_outdated = self.dev.iter().any(|(_, dep)| dep.is_outdated());
         let build_any_outdated = self.build.iter().any(|(_, dep)| dep.is_outdated());
-        main_any_outdated || dev_any_outdated || build_any_outdated
+        main_any_outdated || build_any_outdated
+    }
+
+    /// Counts the number of outdated `dev-dependencies`
+    pub fn count_dev_outdated(&self) -> usize {
+        self.dev
+            .iter()
+            .filter(|&(_, dep)| dep.is_outdated())
+            .count()
+    }
+
+    /// Counts the number of insecure `dev-dependencies`
+    pub fn count_dev_insecure(&self) -> usize {
+        self.dev.iter().filter(|&(_, dep)| dep.insecure).count()
+    }
+
+    /// Returns `true` if any dev-dependencies are either insecure or outdated.
+    pub fn any_dev_issues(&self) -> bool {
+        self.dev
+            .iter()
+            .any(|(_, dep)| dep.is_outdated() || dep.insecure)
     }
 }
 

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -119,6 +119,22 @@ fn render_title(subject_path: &SubjectPath) -> Markup {
     }
 }
 
+fn render_dev_dependency_box(outcome: &AnalyzeDependenciesOutcome) -> Markup {
+    let insecure = outcome.count_dev_insecure();
+    let outdated = outcome.count_dev_outdated();
+    let text = if insecure > 0 {
+        format!("{} insecure development dependencies", insecure)
+    } else {
+        format!("{} outdated development dependencies", outdated)
+    };
+
+    html! {
+        div class="notification is-warning" {
+            p { "This project contains " b { (text) } "." }
+        }
+    }
+}
+
 fn render_failure(subject_path: SubjectPath) -> Markup {
     html! {
         section class="hero is-light" {
@@ -192,6 +208,9 @@ fn render_success(
         }
         section class="section" {
             div class="container" {
+                @if analysis_outcome.any_dev_issues() {
+                    (render_dev_dependency_box(&analysis_outcome))
+                }
                 @for (crate_name, deps) in analysis_outcome.crates {
                     (dependency_tables(crate_name, deps))
                 }


### PR DESCRIPTION
This PR closes #35 by excluding `dev-dependencies` from the project assessment. An example to test this on can be the `telegram-bot` package:
> http://localhost:8080/crate/telegram-bot/0.7.0

As we have discussed, we may also want to be able to remove build dependencies from the badge, but I figured that this might be something for a different PR.

I will request two reviews, whoever reviews it first may merge afterwards (also feel free to self-request a review!). :)