### PR TITLE
Show number of outdated dependencies even if insecure crates are present

### DIFF
--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -42,9 +42,9 @@ fn dependency_table(title: &str, deps: IndexMap<CrateName, AnalyzedDependency>) 
         h3 class="title is-4" { (title) }
         p class="subtitle is-5" {
             @if count_insecure > 0 {
-                (format!(" ({} total, {} insecure)", count_total, count_insecure))
+                (format!(" ({} total, {} outdated, {} insecure)", count_total, count_outdated, count_insecure))
             } @else if count_outdated > 0 {
-                (format!(" ({} total, {} up-to-date, {} outdated)", count_total, count_total - count_outdated, count_outdated))
+                (format!(" ({} total, {} outdated)", count_total, count_outdated))
             } @else {
                 (format!(" ({} total, all up-to-date)", count_total))
             }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -41,13 +41,12 @@ fn dependency_table(title: &str, deps: IndexMap<CrateName, AnalyzedDependency>) 
     html! {
         h3 class="title is-4" { (title) }
         p class="subtitle is-5" {
-            @if count_insecure > 0 {
-                (format!(" ({} total, {} outdated, {} insecure)", count_total, count_outdated, count_insecure))
-            } @else if count_outdated > 0 {
-                (format!(" ({} total, {} outdated)", count_total, count_outdated))
-            } @else {
-                (format!(" ({} total, all up-to-date)", count_total))
-            }
+            (match (count_outdated, count_insecure) {
+                (0, 0) => format!("({} total, all up-to-date)", count_total),
+                (0, _) => format!("({} total, {} insecure)", count_total, count_insecure),
+                (_, 0) => format!("({} total, {} outdated)", count_total, count_outdated),
+                (_, _) => format!("({} total, {} outdated, {} insecure)", count_total, count_outdated, count_insecure),
+            })
         }
 
         table class="table is-fullwidth is-striped is-hoverable" {


### PR DESCRIPTION
I have also removed the part showing the number of up-to-date crates as I think it's not that informative and can easily be figured out from the other information.