### PR TITLE
Fix dev dependencies being counted as main dependencies

### DIFF
--- a/src/interactors/crates.rs
+++ b/src/interactors/crates.rs
@@ -48,7 +48,7 @@ fn convert_pkgs(krate: Crate) -> Result<QueryCrateResponse, Error> {
 
                 match dep.kind() {
                     DependencyKind::Normal => deps.main.insert(name, CrateDep::External(req)),
-                    DependencyKind::Dev => deps.main.insert(name, CrateDep::External(req)),
+                    DependencyKind::Dev => deps.dev.insert(name, CrateDep::External(req)),
                     _ => None,
                 };
             }


### PR DESCRIPTION
Fixes a mistake I made in [#69](https://github.com/deps-rs/deps.rs/pull/69/files#diff-3cbeff58e0bfae417a9490e5dcc6a391a382ee4f0f00073fc0376117200cbfd4), which resulted into dev dependencies for crates.io-index crates being counted as normal dependencies

![before and after](https://user-images.githubusercontent.com/6215781/101995490-6f1a7f80-3cca-11eb-955d-34f074460453.png)

Before and After
