### PR TITLE
Display rustsec information on page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1072,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1415,7 @@ dependencies = [
  "maud",
  "once_cell",
  "pin-project 1.0.2",
+ "pulldown-cmark",
  "relative-path",
  "reqwest",
  "route-recognizer",
@@ -1724,6 +1746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1771,12 @@ checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
  "time",
  "winapi",
 ]
@@ -534,6 +533,22 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -1187,23 +1202,25 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5982d0d4f57176e3e8d62452a5d6dab98906ee5ab4ad1cb63c0877f0a16ab0e"
+checksum = "7989ff58001a2be1c17945e53d32fcad5cf33c638a4b1239d6e1c9aff7a5d2f8"
 dependencies = [
  "cargo-lock",
- "chrono",
  "crates-index 0.16.2",
  "cvss",
  "fs-err",
  "git2",
  "home",
+ "humantime",
+ "humantime-serde",
  "platforms",
  "semver 0.11.0",
  "serde",
  "smol_str",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -1456,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
 dependencies = [
  "serde",
 ]
@@ -1740,6 +1757,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hyper = { version = "0.14", features = ["full"] }
 indexmap = { version = "1", features = ["serde-1"] }
 lru_time_cache = "0.11.1"
 maud = "0.22.1"
+pulldown-cmark = "0.8"
 once_cell = "1"
 pin-project = "1"
 relative-path = { version = "1.3", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1"
 pin-project = "1"
 relative-path = { version = "1.3", features = ["serde"] }
 route-recognizer = "0.3"
-rustsec = "0.22"
+rustsec = "0.23"
 crates-index = "0.15" # held back by semver 0.11
 semver = { version = "0.10", features = ["serde"] } # held at 0.10 due to #63
 reqwest = { version = "0.11", features = ["json"] }

--- a/src/engine/machines/analyzer.rs
+++ b/src/engine/machines/analyzer.rs
@@ -43,10 +43,10 @@ impl DependencyAnalyzer {
             let query = database::Query::new().package_version(name, version);
 
             if let Some(db) = advisory_db {
-                let mut vulnerabilities = db.query(&query);
+                let vulnerabilities = db.query(&query);
                 if !vulnerabilities.is_empty() {
                     dep.vulnerabilities =
-                        Some(vulnerabilities.drain(..).map(|v| v.to_owned()).collect());
+                        vulnerabilities.into_iter().map(|v| v.to_owned()).collect();
                 }
             }
         }

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -90,7 +90,7 @@ pub struct AnalyzedDependency {
     pub required: VersionReq,
     pub latest_that_matches: Option<Version>,
     pub latest: Option<Version>,
-    pub vulnerabilities: Option<Vec<Advisory>>,
+    pub vulnerabilities: Vec<Advisory>,
 }
 
 impl AnalyzedDependency {
@@ -99,12 +99,12 @@ impl AnalyzedDependency {
             required,
             latest_that_matches: None,
             latest: None,
-            vulnerabilities: None,
+            vulnerabilities: Vec::new(),
         }
     }
 
     pub fn is_insecure(&self) -> bool {
-        self.vulnerabilities.is_some()
+        !self.vulnerabilities.is_empty()
     }
 
     pub fn is_outdated(&self) -> bool {


### PR DESCRIPTION
This PR adds functionality to close #75.
RustSec advisories affecting a repository are now listed with some additional information at the bottom of the page. This encompasses the description of the CVE, a list of unaffected and fixed versions as well as a link to the RustSec page (which I have to generate manually based on their URL scheme so pray that this will never change).

## Dependency changes
- I bumped the `rustsec` crate version to the latest release. Since I was going to touch most of the code using this crate anyway I thought using the most up-to-date version would be wise.
- I added `pulldown-cmark` as a dependency to render the CVE descriptions (which are markdown). This might be a bit overkill, but if anybody knows a maintained, well-functioning, small Markdown renderer raise your hands. 😄

## Code changes
I significantly expanded `src/server/views/html/status.rs` to add the functionality. If someone feels like cleaning this up or has suggestions for cleaner code, do speak up :)