### PR TITLE
Only query advisory database on latest matching version

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -108,6 +108,13 @@ impl AnalyzeDependenciesOutcome {
             .any(|&(_, ref deps)| deps.count_insecure() > 0)
     }
 
+    /// Checks if any always insecure main or build dependencies exist in the scanned crates
+    pub fn any_always_insecure(&self) -> bool {
+        self.crates
+            .iter()
+            .any(|&(_, ref deps)| deps.count_always_insecure() > 0)
+    }
+
     /// Checks if any dev-dependencies in the scanned crates are either outdated or insecure
     pub fn any_dev_issues(&self) -> bool {
         self.crates

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -103,8 +103,24 @@ impl AnalyzedDependency {
         }
     }
 
+    /// Check whether this dependency has at least one known vulnerability
+    /// in any version in the required version range.
+    ///
+    /// Note that the vulnerability may (or not) already be patched
+    /// in the latest version(s) in the range.
     pub fn is_insecure(&self) -> bool {
         !self.vulnerabilities.is_empty()
+    }
+
+    /// Check whether this dependency has at laest one known vulnerability
+    /// even when the latest version in the required range is used.
+    pub fn is_always_insecure(&self) -> bool {
+        if let Some(latest) = &self.latest {
+            self.vulnerabilities.iter()
+                .any(|a| a.versions.is_vulnerable(latest))
+        } else {
+            self.is_insecure()
+        }
     }
 
     pub fn is_outdated(&self) -> bool {
@@ -199,6 +215,23 @@ impl AnalyzedDependencies {
         main_insecure + build_insecure
     }
 
+    /// Returns the number of main and build dependencies
+    /// which are vulnerable to security issues,
+    /// even they are updated to the latest version in the required range.
+    pub fn count_always_insecure(&self) -> usize {
+        let main_insecure = self
+            .main
+            .iter()
+            .filter(|&(_, dep)| dep.is_always_insecure())
+            .count();
+        let build_insecure = self
+            .build
+            .iter()
+            .filter(|&(_, dep)| dep.is_always_insecure())
+            .count();
+        main_insecure + build_insecure
+    }
+    
     /// Checks if any outdated main or build dependencies exist
     pub fn any_outdated(&self) -> bool {
         let main_any_outdated = self.main.iter().any(|(_, dep)| dep.is_outdated());

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -116,7 +116,8 @@ impl AnalyzedDependency {
     /// even when the latest version in the required range is used.
     pub fn is_always_insecure(&self) -> bool {
         if let Some(latest) = &self.latest {
-            self.vulnerabilities.iter()
+            self.vulnerabilities
+                .iter()
                 .any(|a| a.versions.is_vulnerable(latest))
         } else {
             self.is_insecure()
@@ -231,7 +232,7 @@ impl AnalyzedDependencies {
             .count();
         main_insecure + build_insecure
     }
-    
+
     /// Checks if any outdated main or build dependencies exist
     pub fn any_outdated(&self) -> bool {
         let main_any_outdated = self.main.iter().any(|(_, dep)| dep.is_outdated());

--- a/src/server/views/badge.rs
+++ b/src/server/views/badge.rs
@@ -7,7 +7,7 @@ use crate::engine::AnalyzeDependenciesOutcome;
 pub fn badge(analysis_outcome: Option<&AnalyzeDependenciesOutcome>) -> Badge {
     let opts = match analysis_outcome {
         Some(outcome) => {
-            if outcome.any_insecure() {
+            if outcome.any_always_insecure() {
                 BadgeOptions {
                     subject: "dependencies".into(),
                     status: "insecure".into(),
@@ -23,10 +23,18 @@ pub fn badge(analysis_outcome: Option<&AnalyzeDependenciesOutcome>) -> Badge {
                         color: "#dfb317".into(),
                     }
                 } else if total > 0 {
-                    BadgeOptions {
-                        subject: "dependencies".into(),
-                        status: "up to date".into(),
-                        color: "#4c1".into(),
+                    if outcome.any_insecure() {
+                        BadgeOptions {
+                            subject: "dependencies".into(),
+                            status: "maybe insecure".into(),
+                            color: "#8b1".into(),
+                        }
+                    } else {
+                        BadgeOptions {
+                            subject: "dependencies".into(),
+                            status: "up to date".into(),
+                            color: "#4c1".into(),
+                        }
                     }
                 } else {
                     BadgeOptions {

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -47,7 +47,10 @@ fn dependency_tables(crate_name: &CrateName, deps: &AnalyzedDependencies) -> Mar
 
 fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>) -> Markup {
     let count_total = deps.len();
-    let count_always_insecure = deps.iter().filter(|&(_, dep)| dep.is_always_insecure()).count();
+    let count_always_insecure = deps
+        .iter()
+        .filter(|&(_, dep)| dep.is_always_insecure())
+        .count();
     let count_insecure = deps.iter().filter(|&(_, dep)| dep.is_insecure()).count();
     let count_outdated = deps.iter().filter(|&(_, dep)| dep.is_outdated()).count();
 
@@ -86,7 +89,7 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
                             }
                             { "\u{00A0}" } // non-breaking space
                             a href=(dep.deps_rs_path(name.as_ref())) { (name.as_ref()) }
-                            
+
                             @if dep.is_insecure() {
                                 { "\u{00A0}" } // non-breaking space
                                 a href="#vulnerabilities" title="has known vulnerabilities" { "⚠️" }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -342,7 +342,9 @@ fn render_success(
                     div class="notification is-warning" {
                         p { "This project might be open to "
                             b { "known security vulnerabilities" }
-                            ". Find detailed information at the "
+                            ", which can be prevented by tightening "
+                            "the version range of affected dependencies. "
+                            "Find detailed information at the "
                             a href="#vulnerabilities" { "bottom"} "."
                         }
                     }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -56,13 +56,15 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
     html! {
         h3 class="title is-4" { (title) }
         p class="subtitle is-5" {
-            (match (count_outdated, count_always_insecure, count_insecure) {
+            (match (count_outdated, count_always_insecure, count_insecure - count_always_insecure) {
                 (0, 0, 0) => format!("({} total, all up-to-date)", count_total),
-                (0, _, 0) => format!("({} total, {} insecure)", count_total, count_always_insecure),
-                (0, 0, _) => format!("({} total, {} possibly insecure)", count_total, count_insecure - count_always_insecure),
-                (0, _, _) => format!("({} total, {} insecure, {} possibly insecure)", count_total, count_always_insecure, count_insecure - count_always_insecure),
+                (0, 0, c) => format!("({} total, {} possibly insecure)", count_total, c),
                 (_, 0, 0) => format!("({} total, {} outdated)", count_total, count_outdated),
-                (_, _, _) => format!("({} total, {} outdated, {} insecure, {} possibly insecure)", count_total, count_outdated, count_always_insecure, count_insecure - count_always_insecure),
+                (0, _, 0) => format!("({} total, {} insecure)", count_total, count_always_insecure),
+                (0, _, c) => format!("({} total, {} insecure, {} possibly insecure)", count_total, count_always_insecure, c),
+                (_, 0, c) => format!("({} total, {} outdated, {} possibly insecure)", count_total, count_outdated, c),
+                (_, _, 0) => format!("({} total, {} outdated, {} insecure)", count_total, count_outdated, count_always_insecure),
+                (_, _, c) => format!("({} total, {} outdated, {} insecure, {} possibly insecure)", count_total, count_outdated, count_always_insecure, c),
             })
         }
 


### PR DESCRIPTION
This pull request creates a new distinction between dependencies which are

- _always insecure_: shown in red, where even the latest version (in range) of a dependency is not patched;
-  _possibly insecure_: (has at least one vulnerability in any version in the range) 

Resolves #94 ~~, and also reduces the number of queries to the advisory DB.~~


Summary:

- Update project status page
   - show always insecure dependencies as insecure, and remaining ones as "possibly insecure"
   - show warning sign on all dependencies with possible vulnerability
   - tweak security banner in case all insecure dependencies are "possibly insecure"
- Update badge
   - Only show the red "insecure" if at least one dependency is always insecure
   - show "possibly insecure" if all are up to date but might be vulnerable
