### PR TITLE
Use font-awesome-as-a-crate instead of importing the entire Font Awesome library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "font-awesome-as-a-crate"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12cc52b2062ad4cb425d969c77325dd3da70312ed7ed892c7e8143384da58aa"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1414,7 @@ dependencies = [
  "cadence",
  "crates-index 0.15.0",
  "derive_more",
+ "font-awesome-as-a-crate",
  "futures",
  "hyper",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ slog-async = "2"
 slog-term = "2"
 tokio = { version = "1.0.1", features = ["full"] }
 toml = "0.5"
+font-awesome-as-a-crate = "0.1.2"
 
 [build-dependencies]
 sass-rs = "0.2"

--- a/assets/styles/fa.sass
+++ b/assets/styles/fa.sass
@@ -1,0 +1,7 @@
+/* Stop icons from using up all of the available space */
+svg
+    width: 1em
+    height: 1em
+    fill: currentColor
+    /* pull icon about one stroke width into the descenders */
+    margin-bottom: -0.1em

--- a/assets/styles/main.sass
+++ b/assets/styles/main.sass
@@ -1,5 +1,7 @@
 @charset "utf-8";
 
+@import "./fa.sass";
+
 @import "bulma/utilities/initial-variables";
 @import "bulma/utilities/functions";
 

--- a/src/server/views/html/mod.rs
+++ b/src/server/views/html/mod.rs
@@ -21,7 +21,6 @@ fn render_html<B: Render>(title: &str, body: B) -> Response<Body> {
                 link rel="stylesheet" type="text/css" href="/static/style.css";
                 link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Fira+Sans:400,500,600";
                 link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Code+Pro";
-                link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css";
             }
             body { (body) }
         }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -1,3 +1,4 @@
+use font_awesome_as_a_crate::{svg as fa, Type as FaType};
 use hyper::{Body, Response};
 use indexmap::IndexMap;
 use maud::{html, Markup, PreEscaped};
@@ -49,6 +50,8 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
     let count_insecure = deps.iter().filter(|&(_, dep)| dep.is_insecure()).count();
     let count_outdated = deps.iter().filter(|&(_, dep)| dep.is_outdated()).count();
 
+    let fa_cube = PreEscaped(fa(FaType::Solid, "cube").unwrap());
+
     html! {
         h3 class="title is-4" { (title) }
         p class="subtitle is-5" {
@@ -74,7 +77,7 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
                     tr {
                         td {
                             a class="has-text-grey" href=(get_crates_url(&name)) {
-                                i class=("fa fa-cube") { "" }
+                                { (fa_cube) }
                             }
                             { "\u{00A0}" } // non-breaking space
                             a href=(dep.deps_rs_path(name.as_ref())) { (name.as_ref()) }
@@ -105,9 +108,9 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
 
 fn get_site_icon(site: &RepoSite) -> &'static str {
     match *site {
-        RepoSite::Github => "fa-github",
-        RepoSite::Gitlab => "fa-gitlab",
-        RepoSite::Bitbucket => "fa-bitbucket",
+        RepoSite::Github => "github",
+        RepoSite::Gitlab => "gitlab",
+        RepoSite::Bitbucket => "bitbucket",
     }
 }
 
@@ -115,17 +118,21 @@ fn render_title(subject_path: &SubjectPath) -> Markup {
     match *subject_path {
         SubjectPath::Repo(ref repo_path) => {
             let site_icon = get_site_icon(&repo_path.site);
+            let fa_site_icon = PreEscaped(fa(FaType::Brands, site_icon).unwrap());
+
             html! {
                 a href=(format!("{}/{}/{}", repo_path.site.to_base_uri(), repo_path.qual.as_ref(), repo_path.name.as_ref())) {
-                    i class=(format!("fa {}", site_icon)) { "" }
+                    { (fa_site_icon) }
                     (format!(" {} / {}", repo_path.qual.as_ref(), repo_path.name.as_ref()))
                 }
             }
         }
         SubjectPath::Crate(ref crate_path) => {
+            let fa_cube = PreEscaped(fa(FaType::Solid, "cube").unwrap());
+
             html! {
                 a href=(get_crates_version_url(&crate_path.name, &crate_path.version)) {
-                    i class="fa fa-cube" { "" }
+                    { (fa_cube) }
                     (format!(" {} {}", crate_path.name.as_ref(), crate_path.version))
                 }
             }


### PR DESCRIPTION
This cuts off about 100 kBs between CSS and font files used for the Font Awesome icons. Instead of importing a huge font file that contains all of the icons, the few icons that we use are inlined into the HTML as SVGs.

Also this upgrades us to Font Awesome 5.

## html size comparison

_https://deps.rs/repo/github/rusoto/rusoto was used for this test, which is a bit of an extreme example because of the number of crates in the workspace_

|       | Uncompressed | gzip -9 |
| ----------- | ----------- | -------------|
| Before      | 648 kB       | 12 kB |
| After   | 1.2 MB        | 16 kB |

