### PR TITLE
clippy: fix clippy::from_over_into warning

### DIFF
--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -24,9 +24,9 @@ impl CratePath {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CrateName(String);
 
-impl Into<String> for CrateName {
-    fn into(self) -> String {
-        self.0
+impl From<CrateName> for String {
+    fn from(crate_name: CrateName) -> String {
+        crate_name.0
     }
 }
 


### PR DESCRIPTION
Fixes clippy 1.51 warnings