### PR TITLE
Add support for projects hosted on sourcehut (sr.ht)

### DIFF
--- a/src/models/repo.rs
+++ b/src/models/repo.rs
@@ -54,6 +54,7 @@ pub enum RepoSite {
     Github,
     Gitlab,
     Bitbucket,
+    Sourcehut,
 }
 
 impl RepoSite {
@@ -62,6 +63,7 @@ impl RepoSite {
             RepoSite::Github => "https://github.com",
             RepoSite::Gitlab => "https://gitlab.com",
             RepoSite::Bitbucket => "https://bitbucket.org",
+            RepoSite::Sourcehut => "https://git.sr.ht",
         }
     }
 
@@ -70,6 +72,7 @@ impl RepoSite {
             RepoSite::Github => "https://raw.githubusercontent.com",
             RepoSite::Gitlab => "https://gitlab.com",
             RepoSite::Bitbucket => "https://bitbucket.org",
+            RepoSite::Sourcehut => "https://git.sr.ht",
         }
     }
 
@@ -77,6 +80,7 @@ impl RepoSite {
         match self {
             RepoSite::Github => "HEAD",
             RepoSite::Gitlab | RepoSite::Bitbucket => "raw/HEAD",
+            RepoSite::Sourcehut => "blob/HEAD",
         }
     }
 }
@@ -89,6 +93,7 @@ impl FromStr for RepoSite {
             "github" => Ok(RepoSite::Github),
             "gitlab" => Ok(RepoSite::Gitlab),
             "bitbucket" => Ok(RepoSite::Bitbucket),
+            "sourcehut" => Ok(RepoSite::Sourcehut),
             _ => Err(anyhow!("unknown repo site identifier")),
         }
     }
@@ -100,6 +105,7 @@ impl AsRef<str> for RepoSite {
             RepoSite::Github => "github",
             RepoSite::Gitlab => "gitlab",
             RepoSite::Bitbucket => "bitbucket",
+            RepoSite::Sourcehut => "sourcehut",
         }
     }
 }
@@ -111,9 +117,12 @@ impl FromStr for RepoQualifier {
     type Err = Error;
 
     fn from_str(input: &str) -> Result<RepoQualifier, Error> {
-        let is_valid = input
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_');
+        let is_valid = input.chars().all(|c| {
+            c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'
+                 // Sourcehut projects have the form
+                 // https://git.sr.ht/~user/project.
+                 || c == '~'
+        });
 
         ensure!(is_valid, "invalid repo qualifier");
         Ok(RepoQualifier(input.to_string()))

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -106,11 +106,14 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
     }
 }
 
-fn get_site_icon(site: &RepoSite) -> &'static str {
+fn get_site_icon(site: &RepoSite) -> (FaType, &'static str) {
     match *site {
-        RepoSite::Github => "github",
-        RepoSite::Gitlab => "gitlab",
-        RepoSite::Bitbucket => "bitbucket",
+        RepoSite::Github => (FaType::Brands, "github"),
+        RepoSite::Gitlab => (FaType::Brands, "gitlab"),
+        RepoSite::Bitbucket => (FaType::Brands, "bitbucket"),
+        // FIXME: There is no brands/sourcehut icon, so just use a regular
+        // circle which looks pretty much like sr.ht's circle.
+        RepoSite::Sourcehut => (FaType::Regular, "circle"),
     }
 }
 
@@ -118,7 +121,7 @@ fn render_title(subject_path: &SubjectPath) -> Markup {
     match *subject_path {
         SubjectPath::Repo(ref repo_path) => {
             let site_icon = get_site_icon(&repo_path.site);
-            let fa_site_icon = PreEscaped(fa(FaType::Brands, site_icon).unwrap());
+            let fa_site_icon = PreEscaped(fa(site_icon.0, site_icon.1).unwrap());
 
             html! {
                 a href=(format!("{}/{}/{}", repo_path.site.to_base_uri(), repo_path.qual.as_ref(), repo_path.name.as_ref())) {


### PR DESCRIPTION
Sourcehut git projects (https://git.sr.ht) are supported with the repo specifiers

    /repo/sr.ht/~user/project
    /repo/srht/~user/project
    /repo/sourcehut/~user/project

This solves feature request #115.

(Note that sourcehut also offers mercurial/hg hosting at https://hg.sr.ht which is not supported.)