### PR TITLE
Update dependencies crates-index and rustsec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,11 +84,11 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "6.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f16e7adc20969298b1e137ac21ab3a7e7a9412fec71f963ff2fdc41663d70f"
+checksum = "7fb04b88bd5b2036e30704f95c6ee16f3b5ca3b4ca307da2889d9006648e5c88"
 dependencies = [
- "semver 0.11.0",
+ "semver",
  "serde",
  "toml",
  "url",
@@ -155,16 +155,16 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.16.6"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9880def1f3f60a7774aeccc2965f4609292dbf49dbfab2cc1f63e474a531b2e"
+checksum = "8ad4af5c8dd9940a497ef4473e6e558b660a4a1b6e5ce2cb9d85454e2aaaf947"
 dependencies = [
  "git2",
  "glob",
  "hex",
  "home",
  "memchr",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -927,15 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,9 +1165,9 @@ checksum = "824172f0afccf3773c3905f5550ac94572144efe0deaf49a1f22bbca188d193e"
 
 [[package]]
 name = "rustsec"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ca2e5b11f379d6f091b029f4efbcf77c2e5ce61628a3512944ac1718eafba5"
+checksum = "c29c220a60ceaeedb2c5bf51826b3d3c5d77b2523693f0579c8a85dd03f11947"
 dependencies = [
  "cargo-lock",
  "crates-index",
@@ -1187,7 +1178,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "platforms",
- "semver 0.11.0",
+ "semver",
  "serde",
  "smol_str",
  "thiserror",
@@ -1280,30 +1271,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -1385,7 +1357,7 @@ dependencies = [
  "route-recognizer",
  "rustsec",
  "sass-rs",
- "semver 1.0.3",
+ "semver",
  "serde",
  "serde_json",
  "sha-1",
@@ -1683,12 +1655,6 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ once_cell = "1"
 pin-project = "1"
 relative-path = { version = "1.3", features = ["serde"] }
 route-recognizer = "0.3"
-rustsec = "0.23"
-crates-index = "0.16"
+rustsec = "0.24"
+crates-index = "0.17"
 semver = { version = "1.0", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/engine/machines/analyzer.rs
+++ b/src/engine/machines/analyzer.rs
@@ -46,7 +46,7 @@ impl DependencyAnalyzer {
                 let vulnerabilities: Vec<_> = db
                     .query(&query)
                     .into_iter()
-                    .filter(|vuln| vuln.metadata.withdrawn.is_none())
+                    .filter(|vuln| !vuln.withdrawn())
                     .map(|v| v.to_owned())
                     .collect();
                 if !vulnerabilities.is_empty() {

--- a/src/engine/machines/analyzer.rs
+++ b/src/engine/machines/analyzer.rs
@@ -46,7 +46,7 @@ impl DependencyAnalyzer {
                 let vulnerabilities: Vec<_> = db
                     .query(&query)
                     .into_iter()
-                    .filter(|vuln| !vuln.metadata.yanked)
+                    .filter(|vuln| vuln.metadata.withdrawn.is_none())
                     .map(|v| v.to_owned())
                     .collect();
                 if !vulnerabilities.is_empty() {

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -215,10 +215,10 @@ fn vulnerability_list(analysis_outcome: &AnalyzeDependenciesOutcome) -> Markup {
                     div class="level-item has-text-centered" {
                         div {
                             p class="heading" { "Unaffected" }
-                            @if vuln.versions.unaffected.is_empty() {
+                            @if vuln.versions.unaffected().is_empty() {
                                 p class="is-grey" { "None"}
                             } @else {
-                                @for item in &vuln.versions.unaffected {
+                                @for item in vuln.versions.unaffected() {
                                     p { code { (item) } }
                                 }
                             }
@@ -227,10 +227,10 @@ fn vulnerability_list(analysis_outcome: &AnalyzeDependenciesOutcome) -> Markup {
                     div class="level-item has-text-centered" {
                         div {
                             p class="heading" { "Patched" }
-                            @if vuln.versions.unaffected.is_empty() {
+                            @if vuln.versions.unaffected().is_empty() {
                                 p class="has-text-grey" { "None"}
                             } @else {
-                                @for item in &vuln.versions.patched {
+                                @for item in vuln.versions.patched() {
                                     p { code { (item) } }
                                 }
                             }


### PR DESCRIPTION
Both are now based on `semver` v1, so it should be safe to bring them in.

The code was adapted to changes in `rustsec`.
- Advisory metadata `yanked` is seemingly now called `withdrawn`
- Versions `unaffected` and `patched` are now retrieved via method calls