### PR TITLE
Provide an endpoint to create shields.io badges

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,6 +23,7 @@ use crate::models::SubjectPath;
 enum StatusFormat {
     Html,
     Svg,
+    ShieldsIoJson,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -63,6 +64,10 @@ impl App {
             "/repo/:site/:qual/:name/status.svg",
             Route::RepoStatus(StatusFormat::Svg),
         );
+        router.add(
+            "/repo/:site/:qual/:name/shieldsio.json",
+            Route::RepoStatus(StatusFormat::ShieldsIoJson),
+        );
 
         router.add("/crate/:name", Route::CrateRedirect);
         router.add(
@@ -72,6 +77,10 @@ impl App {
         router.add(
             "/crate/:name/:version/status.svg",
             Route::CrateStatus(StatusFormat::Svg),
+        );
+        router.add(
+            "/crate/:name/:version/shieldsio.json",
+            Route::CrateStatus(StatusFormat::ShieldsIoJson),
         );
 
         App {
@@ -342,6 +351,7 @@ impl App {
         match format {
             StatusFormat::Svg => views::badge::response(analysis_outcome.as_ref()),
             StatusFormat::Html => views::html::status::render(analysis_outcome, subject_path),
+            StatusFormat::ShieldsIoJson => views::shieldsio::response(analysis_outcome.as_ref()),
         }
     }
 

--- a/src/server/views/mod.rs
+++ b/src/server/views/mod.rs
@@ -1,2 +1,3 @@
 pub mod badge;
 pub mod html;
+pub mod shieldsio;

--- a/src/server/views/shieldsio.rs
+++ b/src/server/views/shieldsio.rs
@@ -1,0 +1,70 @@
+use std::borrow::Cow;
+
+use hyper::header::CONTENT_TYPE;
+use hyper::{Body, Response};
+use serde_json::json;
+
+use crate::engine::AnalyzeDependenciesOutcome;
+
+struct EndpointData<'a> {
+    message: Cow<'a, str>,
+    color: &'a str,
+}
+
+fn data(analysis_outcome: Option<&AnalyzeDependenciesOutcome>) -> EndpointData<'_> {
+    match analysis_outcome {
+        Some(outcome) => {
+            if outcome.any_always_insecure() {
+                EndpointData {
+                    message: "insecure".into(),
+                    color: "#e05d44",
+                }
+            } else {
+                let (outdated, total) = outcome.outdated_ratio();
+
+                if outdated > 0 {
+                    EndpointData {
+                        message: format!("{} of {} outdated", outdated, total).into(),
+                        color: "#dfb317",
+                    }
+                } else if total > 0 {
+                    if outcome.any_insecure() {
+                        EndpointData {
+                            message: "maybe insecure".into(),
+                            color: "#88bb11",
+                        }
+                    } else {
+                        EndpointData {
+                            message: "up to date".into(),
+                            color: "#44cc11",
+                        }
+                    }
+                } else {
+                    EndpointData {
+                        message: "none".into(),
+                        color: "#44cc11",
+                    }
+                }
+            }
+        }
+        None => EndpointData {
+            message: "unknown".into(),
+            color: "#9f9f9f",
+        },
+    }
+}
+
+pub fn response(analysis_outcome: Option<&AnalyzeDependenciesOutcome>) -> Response<Body> {
+    let data = data(analysis_outcome);
+    let json = json! {{
+        "schemaVersion": 1,
+        "label": "dependencies",
+        "message": data.message,
+        "color": data.color
+    }};
+
+    Response::builder()
+        .header(CONTENT_TYPE, "application/json; charset=utf-8")
+        .body(Body::from(json.to_string()))
+        .unwrap()
+}


### PR DESCRIPTION
Deps.rs already has its own badge but shields.io allows for a wider variety of themes and customizations. That service has an endpoint feature that gives the option to generate badges for systems that are not natively supported by them.

There are several additional features that can be defined in the data for the endpoint but for now I kept it simple and only provided the basic information that is equivalent to the self-generated badge.

The badge can be easily tested by using a service like `ngrok`:
```
https://img.shields.io/endpoint?url=<temp-ngrok-url>%2Fcrate%2Frand%2F0.8.4%2Fshieldsio.json
```

Currently I'm just not sure where to inform about this feature on the deps page, therefore I made this a draft.
