### PR TITLE
Use `MissedTickBehavior::Delay` for updating crates.io-index

### DIFF
--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -8,7 +8,7 @@ use crates_index::Crate;
 use crates_index::Index;
 use slog::{error, Logger};
 use tokio::task::spawn_blocking;
-use tokio::time;
+use tokio::time::{self, MissedTickBehavior};
 
 #[derive(Clone)]
 pub struct ManagedIndex {
@@ -31,6 +31,7 @@ impl ManagedIndex {
 
     pub async fn refresh_at_interval(&self, update_interval: Duration) {
         let mut update_interval = time::interval(update_interval);
+        update_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
             if let Err(e) = self.refresh().await {


### PR DESCRIPTION
This makes it so that if the crates.io-index takes more than the update interval to update (currently 20 seconds), the `time::Interval` doesn't try to poll the index straight way. I don't know if this might have been the cause of our current issues but I've been finding that the default `Burst` behavior is wrong for most use-cases, so I'm modifying it everywhere `time::interval` is used.

Previous behavior: https://docs.rs/tokio/1.20.1/tokio/time/enum.MissedTickBehavior.html#variant.Burst
New behavior: https://docs.rs/tokio/1.20.1/tokio/time/enum.MissedTickBehavior.html#variant.Delay