### PR TITLE
Support for self-hosted Gitea

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We currently support projects and crates hosted on crates.io, Github, Gitlab, Bi
 To analyze the state of your dependencies you can use the following URLs:
 
 - for projects on crates.io: `https://deps.rs/crate/<NAME>`
-- for projects on Github, Gitlab, Bitbucket, SourceHut, or Codeberg: `https://deps.rs/repo/<HOSTER>/<USER>/<REPO>` (where `<HOSTER>` is either `github`, `gitlab`, `bitbucket`, `sourcehut`, or `codeberg`)
+- for projects on Github, Gitlab, Bitbucket, SourceHut, Codeberg, or Gitea: `https://deps.rs/repo/<HOSTER>/<USER>/<REPO>` (where `<HOSTER>` is either `github`, `gitlab`, `bitbucket`, `sourcehut`, `codeberg`, or `gitea/<DOMAIN>`)
 
 ## Badges
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -58,11 +58,11 @@ impl App {
         router.add("/static/logo.svg", Route::Static(StaticFile::FaviconPng));
 
         router.add(
-            "/repo/:site/:qual/:name",
+            "/repo/*site/:qual/:name",
             Route::RepoStatus(StatusFormat::Html),
         );
         router.add(
-            "/repo/:site/:qual/:name/status.svg",
+            "/repo/*site/:qual/:name/status.svg",
             Route::RepoStatus(StatusFormat::Svg),
         );
 

--- a/src/server/views/html/index.rs
+++ b/src/server/views/html/index.rs
@@ -21,12 +21,12 @@ fn popular_table(popular_repos: Vec<Repository>, popular_crates: Vec<CratePath>)
                         @for repo in popular_repos.into_iter().take(10) {
                             tr {
                                 td {
-                                    a href=(format!("{}/repo/{}/{}/{}", &super::SELF_BASE_URL as &str, repo.path.site.as_ref(), repo.path.qual.as_ref(), repo.path.name.as_ref())) {
+                                    a href=(format!("{}/repo/{}/{}/{}", &super::SELF_BASE_URL as &str, repo.path.site, repo.path.qual.as_ref(), repo.path.name.as_ref())) {
                                         (format!("{} / {}", repo.path.qual.as_ref(), repo.path.name.as_ref()))
                                     }
                                 }
                                 td class="has-text-right" {
-                                    img src=(format!("{}/repo/{}/{}/{}/status.svg", &super::SELF_BASE_URL as &str, repo.path.site.as_ref(), repo.path.qual.as_ref(), repo.path.name.as_ref()));
+                                    img src=(format!("{}/repo/{}/{}/{}/status.svg", &super::SELF_BASE_URL as &str, repo.path.site, repo.path.qual.as_ref(), repo.path.name.as_ref()));
                                 }
                             }
                         }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -127,9 +127,11 @@ fn get_site_icon(site: &RepoSite) -> (FaType, &'static str) {
         RepoSite::Github => (FaType::Brands, "github"),
         RepoSite::Gitlab => (FaType::Brands, "gitlab"),
         RepoSite::Bitbucket => (FaType::Brands, "bitbucket"),
-        // FIXME: There is no brands/{sourcehut, codeberg} icon, so just use a
+        // FIXME: There is no brands/{sourcehut, codeberg, gitea} icon, so just use a
         // regular circle which looks close enough.
-        RepoSite::Sourcehut | RepoSite::Codeberg => (FaType::Regular, "circle"),
+        RepoSite::Sourcehut | RepoSite::Codeberg | RepoSite::Gitea(_) => {
+            (FaType::Regular, "circle")
+        }
     }
 }
 
@@ -334,7 +336,7 @@ fn render_success(
     let self_path = match subject_path {
         SubjectPath::Repo(ref repo_path) => format!(
             "repo/{}/{}/{}",
-            repo_path.site.as_ref(),
+            repo_path.site,
             repo_path.qual.as_ref(),
             repo_path.name.as_ref()
         ),


### PR DESCRIPTION
deps.rs is now available for self-hosted Gitea at
`/repo/gitea/<DOMAIN>/owner/repo`, e. g.
`/repo/gitea/git.example.org/deps-rs/deps.rs`,
`/repo/gitea/git.example.org:1234/deps-rs/deps.rs`,
`/repo/gitea/http://unsafe-gitea.org/deps-rs/deps.rs`.

This _should_ also include support for Gitea hosted in subdirectories,
e. g. `www.example.org/gitea`, though I haven't tested this yet.

If no protocol (`https://`/`http://`) is specified, `https://` is
automatically added to the beginning of the gitea server's URL.
However I could also change this to only accept https. Another
option might be the use of URL-encoding.
I am open for feedback, feel free to suggest changes.

Implementation notes:

- The Router now matches `/repo/*site/:qual/:name` instead of
  `/repo/:site/:qual/:name` to allow for an arbitrary number of
  `/`s before qual and name.
- `RepoSite` now has a new variant `Gitea(GiteaDomain)`.
- `RepoSite` no longer implements `Copy`. However this should not
  be problematic because `Copy`ing was only used for `to_base_uri`,
  `to_usercontent_base_uri` and `to_usercontent_repo_suffix` which
  now accept `&self` references.
- `RepoSite`: `to_base_uri` and `to_usercontent_base_uri` now return
  `&str` instead of `&'static str`.
- `RepoSite` no longer implements `AsRef` and now uses `Display`
  instead.

- updated test `correct_raw_url_generation`
- updated readme

Related to #84, #141