### PR TITLE
Set new icons for Codeberg and Gitea

### DIFF
--- a/src/models/repo.rs
+++ b/src/models/repo.rs
@@ -42,7 +42,7 @@ impl fmt::Display for RepoPath {
         write!(
             f,
             "{} => {}/{}",
-            self.site.to_string(),
+            self.site,
             self.qual.as_ref(),
             self.name.as_ref()
         )
@@ -96,7 +96,7 @@ impl FromStr for RepoSite {
     type Err = Error;
 
     fn from_str(input: &str) -> Result<RepoSite, Error> {
-        if let Some((site, domain)) = input.split_once("/") {
+        if let Some((site, domain)) = input.split_once('/') {
             match site {
                 "gitea" => Ok(RepoSite::Gitea(domain.parse()?)),
                 _ => Err(anyhow!("unknown repo site identifier")),

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -127,11 +127,11 @@ fn get_site_icon(site: &RepoSite) -> (FaType, &'static str) {
         RepoSite::Github => (FaType::Brands, "github"),
         RepoSite::Gitlab => (FaType::Brands, "gitlab"),
         RepoSite::Bitbucket => (FaType::Brands, "bitbucket"),
-        // FIXME: There is no brands/{sourcehut, codeberg, gitea} icon, so just use a
-        // regular circle which looks close enough.
-        RepoSite::Sourcehut | RepoSite::Codeberg | RepoSite::Gitea(_) => {
-            (FaType::Regular, "circle")
-        }
+        // FIXME: There is no brands/{sourcehut, codeberg, gitea} icon, so just use an
+        // icon which looks close enough.
+        RepoSite::Sourcehut => (FaType::Regular, "circle"),
+        RepoSite::Codeberg => (FaType::Solid, "mountain"),
+        RepoSite::Gitea(_) => (FaType::Brands, "git-alt"),
     }
 }
 


### PR DESCRIPTION
I changed the FontAwesome icons for Codeberg and Gitea to better approximate their logos. Screenshots are below.

I also addressed the two Linter errors I oversaw when merging #164 because the CI run showed an internal permission error instead.

---


### Gitea: 
![Screenshot 2022-08-21 at 11-15-22 feliix42 _ inky-ticker - Deps rs](https://user-images.githubusercontent.com/9332912/185785615-8e08ef21-d8a5-4d99-8438-ae6781d2dc26.png)

### Codeberg:
![Screenshot 2022-08-21 at 11-15-59 LieutenantPeriwinkle _ mist - Deps rs](https://user-images.githubusercontent.com/9332912/185785617-2b7de6b3-9dfb-43bb-9c65-e99b9d872402.png)

