### PR TITLE
Add link generators to the front page

### DIFF
--- a/assets/links.js
+++ b/assets/links.js
@@ -13,7 +13,7 @@ function buildRepoLink() {
             formRef.elements["baseUrl"].classList.add("is-danger");
             document.getElementById("baseUrlHelp").classList.add("is-danger");
             let hostName = formRef.elements["hosterSelect"].value;
-            document.getElementById("baseUrlHelp").innerHTML = `A Base URL is required for Hosting Provider ${hostName}.`
+            document.getElementById("baseUrlHelp").textContent = `A Base URL is required for Hosting Provider ${hostName}.`
             
             return;
         }

--- a/assets/links.js
+++ b/assets/links.js
@@ -1,0 +1,41 @@
+function buildRepoLink() {
+    var formRef = document.forms["repoSelect"];
+
+    var hoster = formRef.elements["hosterSelect"].value.toLowerCase();
+    var owner = formRef.elements["owner"].value;
+    var repoName = formRef.elements["repoName"].value;
+
+    if (hoster === "gitea") {
+        var baseUrl = formRef.elements["baseUrl"].value;
+
+        // verify that the Base URL is not empty
+        if(baseUrl.length == 0) {
+            formRef.elements["baseUrl"].classList.add("is-danger");
+            document.getElementById("baseUrlHelp").classList.add("is-danger");
+            var hostName = formRef.elements["hosterSelect"].value;
+            document.getElementById("baseUrlHelp").innerHTML = `A Base URL is required for Hosting Provider ${hostName}.`
+            
+            return;
+        }
+
+        window.location.href = `/repo/${hoster}/${baseUrl}/${owner}/${repoName}`;
+    } else {
+        window.location.href = `/repo/${hoster}/${owner}/${repoName}`;
+    }
+}
+
+function buildCrateLink() {
+    var formRef = document.forms["crateSelect"];
+
+    var crate = formRef.elements["crateName"].value;
+    var crateVer = formRef.elements["crateVersion"].value;
+
+    if (crateVer.length == 0) {
+        console.log("Aight, Imma get da crate");
+        // default to latest version
+        window.location.href = `/crate/${crate}`;
+    } else {
+        console.log("Got a version??");
+        window.location.href = `/crate/${crate}/${crateVer}`;
+    }
+}

--- a/assets/links.js
+++ b/assets/links.js
@@ -1,18 +1,18 @@
 function buildRepoLink() {
-    var formRef = document.forms["repoSelect"];
+    let formRef = document.forms["repoSelect"];
 
-    var hoster = formRef.elements["hosterSelect"].value.toLowerCase();
-    var owner = formRef.elements["owner"].value;
-    var repoName = formRef.elements["repoName"].value;
+    let hoster = formRef.elements["hosterSelect"].value.toLowerCase();
+    let owner = formRef.elements["owner"].value;
+    let repoName = formRef.elements["repoName"].value;
 
     if (hoster === "gitea") {
-        var baseUrl = formRef.elements["baseUrl"].value;
+        let baseUrl = formRef.elements["baseUrl"].value;
 
         // verify that the Base URL is not empty
         if(baseUrl.length == 0) {
             formRef.elements["baseUrl"].classList.add("is-danger");
             document.getElementById("baseUrlHelp").classList.add("is-danger");
-            var hostName = formRef.elements["hosterSelect"].value;
+            let hostName = formRef.elements["hosterSelect"].value;
             document.getElementById("baseUrlHelp").innerHTML = `A Base URL is required for Hosting Provider ${hostName}.`
             
             return;
@@ -25,10 +25,10 @@ function buildRepoLink() {
 }
 
 function buildCrateLink() {
-    var formRef = document.forms["crateSelect"];
+    let formRef = document.forms["crateSelect"];
 
-    var crate = formRef.elements["crateName"].value;
-    var crateVer = formRef.elements["crateVersion"].value;
+    let crate = formRef.elements["crateName"].value;
+    let crateVer = formRef.elements["crateVersion"].value;
 
     if (crateVer.length == 0) {
         console.log("Aight, Imma get da crate");

--- a/assets/links.js
+++ b/assets/links.js
@@ -31,11 +31,9 @@ function buildCrateLink() {
     let crateVer = formRef.elements["crateVersion"].value;
 
     if (crateVer.length == 0) {
-        console.log("Aight, Imma get da crate");
         // default to latest version
         window.location.href = `/crate/${crate}`;
     } else {
-        console.log("Got a version??");
         window.location.href = `/crate/${crate}/${crateVer}`;
     }
 }

--- a/assets/links.js
+++ b/assets/links.js
@@ -9,7 +9,7 @@ function buildRepoLink() {
         let baseUrl = formRef.elements["baseUrl"].value;
 
         // verify that the Base URL is not empty
-        if(baseUrl.length == 0) {
+        if(baseUrl.length === 0) {
             formRef.elements["baseUrl"].classList.add("is-danger");
             document.getElementById("baseUrlHelp").classList.add("is-danger");
             let hostName = formRef.elements["hosterSelect"].value;

--- a/assets/styles/main.sass
+++ b/assets/styles/main.sass
@@ -23,12 +23,16 @@ $family-monospace: "Source Serif Pro", monospace
 @import "bulma/base/generic"
 
 @import "bulma/elements/box"
+@import "bulma/elements/button"
 @import "bulma/elements/container"
 @import "bulma/elements/content"
+@import "bulma/elements/form"
 @import "bulma/elements/notification"
 @import "bulma/elements/table"
 @import "bulma/elements/tag"
 @import "bulma/elements/title"
+
+@import "bulma/form/_all"
 
 @import "bulma/components/level"
 @import "bulma/components/message"

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ fn build_style() -> String {
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    // compile the sass files into a single CSS file to be served and cached
     let style = build_style();
 
     let css_path = Path::new(&out_dir).join("style.css");
@@ -26,4 +27,13 @@ fn main() {
     let hash_path = Path::new(&out_dir).join("style.css.sha1");
     let digest = Sha1::digest(style.as_bytes());
     fs::write(hash_path, format!("{:x}", digest)).unwrap();
+
+    // hash and copy the JS file
+    let js_blob = fs::read("./assets/links.js").unwrap();
+    let js_path = Path::new(&out_dir).join("links.js");
+    fs::write(js_path, &js_blob).unwrap();
+
+    let js_hash_path = Path::new(&out_dir).join("links.js.sha1");
+    let js_digest = Sha1::digest(&js_blob);
+    fs::write(js_hash_path, format!("{:x}", js_digest)).unwrap();
 }

--- a/src/server/assets.rs
+++ b/src/server/assets.rs
@@ -10,3 +10,15 @@ pub const STATIC_STYLE_CSS_ETAG: &str = concat!(
     "\""
 );
 pub static STATIC_FAVICON: &[u8] = include_bytes!("../../assets/logo.svg");
+
+pub static STATIC_LINKS_JS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/links.js"));
+pub const STATIC_LINKS_JS_PATH: &str = concat!(
+    "/static/links.",
+    include_str!(concat!(env!("OUT_DIR"), "/links.js.sha1")),
+    ".js"
+);
+pub const STATIC_LINKS_JS_ETAG: &str = concat!(
+    "\"",
+    include_str!(concat!(env!("OUT_DIR"), "/links.js.sha1")),
+    "\""
+);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,9 @@ use slog::{error, info, o, Logger};
 mod assets;
 mod views;
 
-use self::assets::{STATIC_STYLE_CSS_ETAG, STATIC_STYLE_CSS_PATH, STATIC_LINKS_JS_ETAG, STATIC_LINKS_JS_PATH};
+use self::assets::{
+    STATIC_LINKS_JS_ETAG, STATIC_LINKS_JS_PATH, STATIC_STYLE_CSS_ETAG, STATIC_STYLE_CSS_PATH,
+};
 use crate::engine::{AnalyzeDependenciesOutcome, Engine};
 use crate::models::crates::{CrateName, CratePath};
 use crate::models::repo::RepoPath;
@@ -378,7 +380,7 @@ impl App {
                 .header(ETAG, STATIC_LINKS_JS_ETAG)
                 .header(CACHE_CONTROL, "public, max-age=365000000, immutable")
                 .body(Body::from(assets::STATIC_LINKS_JS))
-                .unwrap()
+                .unwrap(),
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ use slog::{error, info, o, Logger};
 mod assets;
 mod views;
 
-use self::assets::{STATIC_STYLE_CSS_ETAG, STATIC_STYLE_CSS_PATH};
+use self::assets::{STATIC_STYLE_CSS_ETAG, STATIC_STYLE_CSS_PATH, STATIC_LINKS_JS_ETAG, STATIC_LINKS_JS_PATH};
 use crate::engine::{AnalyzeDependenciesOutcome, Engine};
 use crate::models::crates::{CrateName, CratePath};
 use crate::models::repo::RepoPath;
@@ -31,6 +31,7 @@ enum StatusFormat {
 enum StaticFile {
     StyleCss,
     FaviconPng,
+    LinksJs,
 }
 
 enum Route {
@@ -56,6 +57,7 @@ impl App {
 
         router.add(STATIC_STYLE_CSS_PATH, Route::Static(StaticFile::StyleCss));
         router.add("/static/logo.svg", Route::Static(StaticFile::FaviconPng));
+        router.add(STATIC_LINKS_JS_PATH, Route::Static(StaticFile::LinksJs));
 
         router.add(
             "/repo/*site/:qual/:name",
@@ -371,6 +373,12 @@ impl App {
                 .header(CONTENT_TYPE, "image/svg+xml")
                 .body(Body::from(assets::STATIC_FAVICON))
                 .unwrap(),
+            StaticFile::LinksJs => Response::builder()
+                .header(CONTENT_TYPE, "text/javascript; charset=utf-8")
+                .header(ETAG, STATIC_LINKS_JS_ETAG)
+                .header(CACHE_CONTROL, "public, max-age=365000000, immutable")
+                .body(Body::from(assets::STATIC_LINKS_JS))
+                .unwrap()
         }
     }
 }

--- a/src/server/views/html/index.rs
+++ b/src/server/views/html/index.rs
@@ -4,6 +4,94 @@ use maud::{html, Markup};
 use crate::models::crates::CratePath;
 use crate::models::repo::Repository;
 
+use crate::server::assets::STATIC_LINKS_JS_PATH;
+
+fn link_forms() -> Markup {
+    html! {
+        div class="columns" {
+            div class="column" {
+                div class="box" {
+                    h2 class="title c is-3" { "Check a Repository" }
+
+                    form id="repoSelect" action="#" {
+                        div class="field" {
+                            label class="label" { "Hosting Provider" }
+
+                            div class="control" {
+                                div class="select" {
+                                    select id="hosterSelect" {
+                                        option { "Github" }
+                                        option { "Gitlab" }
+                                        option { "Bitbucket" }
+                                        option { "Sourcehut" }
+                                        option { "Codeberg" }
+                                        option { "Gitea" }
+                                    }
+                                }
+                            }
+                        }
+
+                        div class="field" {
+                            label class="label" { "Owner" }
+
+                            div class="control" {
+                                input class="input" type="text" id="owner" placeholder="rust-lang" required;
+                            }
+                        }
+
+                        div class="field" {
+                            label class="label" { "Repository Name" }
+
+                            div class="control" {
+                                input class="input" type="text" id="repoName" placeholder="cargo" required;
+                            }
+                        }
+
+                        div class="field" {
+                            label class="label" { "Git instance URL" }
+
+                            div class="control" {
+                                input class="input" type="text" id="baseUrl" placeholder="gitea.com";
+                            }
+
+                            p class="help" id="baseUrlHelp" { "Base URL of the Git instance the project is hosted on. Only relevant for Gitea Instances." }
+                        }
+
+                        input type="submit" class="button is-primary" value="Check" onclick="buildRepoLink();";
+                    }
+                }
+            }
+            div class="column" {
+                div class="box" {
+                    h2 class="title is-3" { "Check a Crate" }
+
+                    form id="crateSelect" action="#" {
+                        div class="field" {
+                            label class="label" { "Crate Name" }
+
+                            div class="control" {
+                                input class="input" type="text" id="crateName" placeholder="serde-derive" required;
+                            }
+                        }
+
+                        div class="field" {
+                            label class="label" { "Version (optional)" }
+
+                            div class="control" {
+                                input class="input" type="text" id="crateVersion" placeholder="1.0.0";
+                            }
+
+                            p class="help" { "If left blank, defaults to the latest version." }
+                        }
+
+                        input type="submit" class="button is-primary" value="Check" onclick="buildCrateLink();";
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn popular_table(popular_repos: Vec<Repository>, popular_crates: Vec<CratePath>) -> Markup {
     html! {
         div class="columns" {
@@ -83,7 +171,11 @@ pub fn render(popular_repos: Vec<Repository>, popular_crates: Vec<CratePath>) ->
             section class="section" {
                 div class="container" { (popular_table(popular_repos, popular_crates)) }
             }
+            section class="section" {
+                div class="container" { (link_forms()) }
+            }
             (super::render_footer(None))
+            script src=(STATIC_LINKS_JS_PATH) {}
         },
     )
 }


### PR DESCRIPTION
Since the project by now supports numerous different hosters and also self-hosted Gitea repositories, I decided to add two link generators to the front page:

![Screenshot of the new front page](https://user-images.githubusercontent.com/9332912/187038774-9c8e9759-ceaa-4218-8fb7-d1462e84ac50.png)

This should also simplify the addition of features like nestes project paths (#95), at least from an End-User perspective.

I added a new function to generate the forms and some JS to create the links to reduce load on the server for a redirect.

## Caveats

I am not a front-end person! If you see this and feel it's garbage, feel free to point out problems/address them yourself. :)
This has also literally been the first 31 SLoC Javascript in my whole life, so review with caution. 😄 