### PR TITLE
Bump vendored Bulma version

### DIFF
--- a/assets/styles/bulma/README.md
+++ b/assets/styles/bulma/README.md
@@ -1,3 +1,3 @@
-This directory includes a vendored copy of the [bulma](https://github.com/jgthms/bulma) CSS framework.
+This directory includes a vendored copy of the [bulma](https://github.com/jgthms/bulma) CSS framework at revision `514229c985e0146039d6960a220f317876c39f8d`.
 
 Please consult the `LICENSE` file for copyright information.

--- a/assets/styles/bulma/components/card.sass
+++ b/assets/styles/bulma/components/card.sass
@@ -2,7 +2,7 @@
 
 $card-color: $text !default
 $card-background-color: $scheme-main !default
-$card-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$card-shadow: $shadow !default
 $card-radius: 0.25rem !default
 
 $card-header-background-color: transparent !default
@@ -54,6 +54,7 @@ $card-media-margin: $block-spacing !default
     justify-content: center
 
 .card-header-icon
+  +reset
   align-items: center
   cursor: pointer
   display: flex

--- a/assets/styles/bulma/components/dropdown.sass
+++ b/assets/styles/bulma/components/dropdown.sass
@@ -8,7 +8,7 @@ $dropdown-content-offset: 4px !default
 $dropdown-content-padding-bottom: 0.5rem !default
 $dropdown-content-padding-top: 0.5rem !default
 $dropdown-content-radius: $radius !default
-$dropdown-content-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$dropdown-content-shadow: $shadow !default
 $dropdown-content-z: 20 !default
 
 $dropdown-item-color: $text !default

--- a/assets/styles/bulma/components/level.sass
+++ b/assets/styles/bulma/components/level.sass
@@ -1,6 +1,6 @@
 @import "../utilities/mixins"
 
-$level-item-spacing: ($block-spacing / 2) !default
+$level-item-spacing: ($block-spacing * 0.5) !default
 
 .level
   @extend %block

--- a/assets/styles/bulma/components/navbar.sass
+++ b/assets/styles/bulma/components/navbar.sass
@@ -153,6 +153,7 @@ body
   overflow-y: hidden
 
 .navbar-burger
+  @extend %reset
   color: $navbar-burger-color
   +hamburger($navbar-height)
   +ltr-property("margin", auto, false)

--- a/assets/styles/bulma/components/pagination.sass
+++ b/assets/styles/bulma/components/pagination.sass
@@ -88,7 +88,8 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($scheme-invert, 0.2) !default
     border-color: $pagination-focus-border-color
   &:active
     box-shadow: $pagination-shadow-inset
-  &[disabled]
+  &[disabled],
+  &.is-disabled
     background-color: $pagination-disabled-background-color
     border-color: $pagination-disabled-border-color
     box-shadow: none
@@ -134,12 +135,20 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($scheme-invert, 0.2) !default
     flex-shrink: 1
     justify-content: flex-start
     order: 1
+  .pagination-previous,
+  .pagination-next,
+  .pagination-link,
+  .pagination-ellipsis
+    margin-bottom: 0
+    margin-top: 0
   .pagination-previous
     order: 2
   .pagination-next
     order: 3
   .pagination
     justify-content: space-between
+    margin-bottom: 0
+    margin-top: 0
     &.is-centered
       .pagination-previous
         order: 1

--- a/assets/styles/bulma/components/panel.sass
+++ b/assets/styles/bulma/components/panel.sass
@@ -3,7 +3,7 @@
 $panel-margin: $block-spacing !default
 $panel-item-border: 1px solid $border-light !default
 $panel-radius: $radius-large !default
-$panel-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$panel-shadow: $shadow !default
 
 $panel-heading-background-color: $border-light !default
 $panel-heading-color: $text-strong !default

--- a/assets/styles/bulma/elements/box.sass
+++ b/assets/styles/bulma/elements/box.sass
@@ -3,7 +3,7 @@
 $box-color: $text !default
 $box-background-color: $scheme-main !default
 $box-radius: $radius-large !default
-$box-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$box-shadow: $shadow !default
 $box-padding: 1.25rem !default
 
 $box-link-hover-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0 0 1px $link !default

--- a/assets/styles/bulma/elements/button.sass
+++ b/assets/styles/bulma/elements/button.sass
@@ -44,6 +44,7 @@ $button-static-background-color: $scheme-main-ter !default
 $button-static-border-color: $border !default
 
 $button-colors: $colors !default
+$button-responsive-sizes: ("mobile": ("small": ($size-small * 0.75), "normal": ($size-small * 0.875), "medium": $size-small, "large": $size-normal), "tablet-only": ("small": ($size-small * 0.875), "normal": ($size-small), "medium": $size-normal, "large": $size-medium)) !default
 
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
@@ -84,14 +85,14 @@ $button-colors: $colors !default
       height: 1.5em
       width: 1.5em
     &:first-child:not(:last-child)
-      +ltr-property("margin", calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width}), false)
-      +ltr-property("margin", $button-padding-horizontal / 4)
+      +ltr-property("margin", calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width}), false)
+      +ltr-property("margin", $button-padding-horizontal * 0.25)
     &:last-child:not(:first-child)
-      +ltr-property("margin", $button-padding-horizontal / 4, false)
-      +ltr-property("margin", calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width}))
+      +ltr-property("margin", $button-padding-horizontal * 0.25, false)
+      +ltr-property("margin", calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width}))
     &:first-child:last-child
-      margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
-      margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+      margin-left: calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width})
+      margin-right: calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width})
   // States
   &:hover,
   &.is-hovered
@@ -163,7 +164,7 @@ $button-colors: $colors !default
       &[disabled],
       fieldset[disabled] &
         background-color: $color
-        border-color: transparent
+        border-color: $color
         box-shadow: none
       &.is-inverted
         background-color: $color-invert
@@ -343,3 +344,14 @@ $button-colors: $colors !default
       .button:not(.is-fullwidth)
         margin-left: 0.25rem
         margin-right: 0.25rem
+
+@each $bp-name, $bp-sizes in $button-responsive-sizes
+  +breakpoint($bp-name)
+    @each $size, $value in $bp-sizes
+      @if $size != "normal"
+        .button.is-responsive.is-#{$size}
+          font-size: $value
+      @else
+        .button.is-responsive,
+        .button.is-responsive.is-normal
+          font-size: $value

--- a/assets/styles/bulma/elements/content.sass
+++ b/assets/styles/bulma/elements/content.sass
@@ -4,6 +4,8 @@ $content-heading-color: $text-strong !default
 $content-heading-weight: $weight-semibold !default
 $content-heading-line-height: 1.125 !default
 
+$content-block-margin-bottom: 1em !default
+
 $content-blockquote-background-color: $background !default
 $content-blockquote-border-left: 5px solid $border !default
 $content-blockquote-padding: 1.25em 1.5em !default
@@ -16,6 +18,7 @@ $content-table-cell-padding: 0.5em 0.75em !default
 $content-table-cell-heading-color: $text-strong !default
 $content-table-head-cell-border-width: 0 0 2px !default
 $content-table-head-cell-color: $text-strong !default
+$content-table-body-last-row-cell-border-bottom-width: 0 !default
 $content-table-foot-cell-border-width: 2px 0 0 !default
 $content-table-foot-cell-color: $text-strong !default
 
@@ -33,7 +36,7 @@ $content-table-foot-cell-color: $text-strong !default
   pre,
   table
     &:not(:last-child)
-      margin-bottom: 1em
+      margin-bottom: $content-block-margin-bottom
   h1,
   h2,
   h3,
@@ -144,13 +147,15 @@ $content-table-foot-cell-color: $text-strong !default
         &:last-child
           td,
           th
-            border-bottom-width: 0
+            border-bottom-width: $content-table-body-last-row-cell-border-bottom-width
   .tabs
     li + li
       margin-top: 0
   // Sizes
   &.is-small
     font-size: $size-small
+  &.is-normal
+    font-size: $size-normal
   &.is-medium
     font-size: $size-medium
   &.is-large

--- a/assets/styles/bulma/elements/icon.sass
+++ b/assets/styles/bulma/elements/icon.sass
@@ -32,9 +32,15 @@ $icon-text-spacing: 0.25em !default
     flex-grow: 0
     flex-shrink: 0
     &:not(:last-child)
-      margin-right: $icon-text-spacing
+      +ltr
+        margin-right: $icon-text-spacing
+      +rtl
+        margin-left: $icon-text-spacing
     &:not(:first-child)
-      margin-left: $icon-text-spacing
+      +ltr
+        margin-left: $icon-text-spacing
+      +rtl
+        margin-right: $icon-text-spacing
 
 div.icon-text
   display: flex

--- a/assets/styles/bulma/elements/notification.sass
+++ b/assets/styles/bulma/elements/notification.sass
@@ -50,6 +50,3 @@ $notification-colors: $colors !default
         &.is-light
           background-color: $color-light
           color: $color-dark
-  ul
-    list-style: disc
-    padding: 0 40

--- a/assets/styles/bulma/elements/other.sass
+++ b/assets/styles/bulma/elements/other.sass
@@ -13,16 +13,6 @@
   margin-bottom: 5px
   text-transform: uppercase
 
-.highlight
-  @extend %block
-  font-weight: $weight-normal
-  max-width: 100%
-  overflow: hidden
-  padding: 0
-  pre
-    overflow: auto
-    max-width: 100%
-
 .loader
   @extend %loader
 

--- a/assets/styles/bulma/elements/table.sass
+++ b/assets/styles/bulma/elements/table.sass
@@ -7,6 +7,7 @@ $table-cell-border: 1px solid $border !default
 $table-cell-border-width: 0 0 1px !default
 $table-cell-padding: 0.5em 0.75em !default
 $table-cell-heading-color: $text-strong !default
+$table-cell-text-align: left !default
 
 $table-head-cell-border-width: 0 0 2px !default
 $table-head-cell-color: $text-strong !default
@@ -60,7 +61,7 @@ $table-colors: $colors !default
   th
     color: $table-cell-heading-color
     &:not([align])
-      text-align: inherit
+      text-align: $table-cell-text-align
   tr
     &.is-selected
       background-color: $table-row-active-background-color

--- a/assets/styles/bulma/elements/title.sass
+++ b/assets/styles/bulma/elements/title.sass
@@ -43,8 +43,6 @@ $subtitle-negative-margin: -1.25rem !default
   strong
     color: $title-strong-color
     font-weight: $title-strong-weight
-  & + .highlight
-    margin-top: -0.75rem
   &:not(.is-spaced) + .subtitle
     margin-top: $subtitle-negative-margin
   // Sizes

--- a/assets/styles/bulma/form/file.sass
+++ b/assets/styles/bulma/form/file.sass
@@ -49,6 +49,8 @@ $file-colors: $form-colors !default
   // Sizes
   &.is-small
     font-size: $size-small
+  &.is-normal
+    font-size: $size-normal
   &.is-medium
     font-size: $size-medium
     .file-icon

--- a/assets/styles/bulma/form/select.sass
+++ b/assets/styles/bulma/form/select.sass
@@ -66,7 +66,8 @@ $select-colors: $form-colors !default
   // Modifiers
   &.is-disabled
     &::after
-      border-color: $input-disabled-color
+      border-color: $input-disabled-color !important
+      opacity: 0.5
   &.is-fullwidth
     width: 100%
     select

--- a/assets/styles/bulma/grid/columns.sass
+++ b/assets/styles/bulma/grid/columns.sass
@@ -62,9 +62,9 @@ $column-gap: 0.75rem !default
   @for $i from 0 through 12
     .columns.is-mobile > &.is-#{$i}
       flex: none
-      width: percentage($i / 12)
+      width: percentage(divide($i, 12))
     .columns.is-mobile > &.is-offset-#{$i}
-      +ltr-property("margin", percentage($i / 12), false)
+      +ltr-property("margin", percentage(divide($i, 12)), false)
   +mobile
     &.is-narrow-mobile
       flex: none
@@ -120,9 +120,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-mobile
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-mobile
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +tablet
     &.is-narrow,
     &.is-narrow-tablet
@@ -199,10 +199,10 @@ $column-gap: 0.75rem !default
       &.is-#{$i},
       &.is-#{$i}-tablet
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i},
       &.is-offset-#{$i}-tablet
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +touch
     &.is-narrow-touch
       flex: none
@@ -258,9 +258,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-touch
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-touch
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +desktop
     &.is-narrow-desktop
       flex: none
@@ -316,9 +316,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-desktop
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-desktop
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +widescreen
     &.is-narrow-widescreen
       flex: none
@@ -374,9 +374,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-widescreen
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-widescreen
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +fullhd
     &.is-narrow-fullhd
       flex: none
@@ -432,9 +432,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-fullhd
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-fullhd
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
 
 .columns
   +ltr-property("margin", (-$column-gap), false)

--- a/assets/styles/bulma/grid/tiles.sass
+++ b/assets/styles/bulma/grid/tiles.sass
@@ -33,4 +33,4 @@ $tile-spacing: 0.75rem !default
     @for $i from 1 through 12
       &.is-#{$i}
         flex: none
-        width: ($i / 12) * 100%
+        width: (divide($i, 12)) * 100%

--- a/assets/styles/bulma/helpers/spacing.sass
+++ b/assets/styles/bulma/helpers/spacing.sass
@@ -8,7 +8,7 @@ $spacing-shortcuts: ("margin": "m", "padding": "p") !default
 $spacing-directions: ("top": "t", "right": "r", "bottom": "b", "left": "l") !default
 $spacing-horizontal: "x" !default
 $spacing-vertical: "y" !default
-$spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5": 1.5rem, "6": 3rem) !default
+$spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5": 1.5rem, "6": 3rem, "auto": auto) !default
 
 @each $property, $shortcut in $spacing-shortcuts
   @each $name, $value in $spacing-values

--- a/assets/styles/bulma/helpers/typography.sass
+++ b/assets/styles/bulma/helpers/typography.sass
@@ -72,6 +72,9 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
 
 .is-italic
   font-style: italic !important
+  
+.is-underlined
+  text-decoration: underline !important
 
 .has-text-weight-light
   font-weight: $weight-light !important

--- a/assets/styles/bulma/layout/hero.sass
+++ b/assets/styles/bulma/layout/hero.sass
@@ -1,9 +1,10 @@
 @import "../utilities/mixins"
 
 $hero-body-padding: 3rem 1.5rem !default
+$hero-body-padding-tablet: 3rem 3rem !default
 $hero-body-padding-small: 1.5rem !default
-$hero-body-padding-medium: 9rem 1.5rem !default
-$hero-body-padding-large: 18rem 1.5rem !default
+$hero-body-padding-medium: 9rem 4.5rem !default
+$hero-body-padding-large: 18rem 6rem !default
 
 $hero-colors: $colors !default
 
@@ -55,6 +56,7 @@ $hero-colors: $colors !default
             opacity: 1
         li
           &.is-active a
+            color: $color !important
             opacity: 1
         &.is-boxed,
         &.is-toggle
@@ -147,3 +149,5 @@ $hero-colors: $colors !default
   flex-grow: 1
   flex-shrink: 0
   padding: $hero-body-padding
+  +tablet
+    padding: $hero-body-padding-tablet

--- a/assets/styles/bulma/layout/section.sass
+++ b/assets/styles/bulma/layout/section.sass
@@ -1,13 +1,15 @@
 @import "../utilities/mixins"
 
 $section-padding: 3rem 1.5rem !default
-$section-padding-medium: 9rem 1.5rem !default
-$section-padding-large: 18rem 1.5rem !default
+$section-padding-desktop: 3rem 3rem !default
+$section-padding-medium: 9rem 4.5rem !default
+$section-padding-large: 18rem 6rem !default
 
 .section
   padding: $section-padding
   // Responsiveness
   +desktop
+    padding: $section-padding-desktop
     // Sizes
     &.is-medium
       padding: $section-padding-medium

--- a/assets/styles/bulma/utilities/derived-variables.sass
+++ b/assets/styles/bulma/utilities/derived-variables.sass
@@ -99,6 +99,10 @@ $size-normal: $size-6 !default
 $size-medium: $size-5 !default
 $size-large: $size-4 !default
 
+// Effects
+
+$shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+
 // Lists and maps
 $custom-colors: null !default
 $custom-shades: null !default

--- a/assets/styles/bulma/utilities/extends.sass
+++ b/assets/styles/bulma/utilities/extends.sass
@@ -20,3 +20,6 @@
 
 %overlay
   +overlay
+
+%reset
+  +reset

--- a/assets/styles/bulma/utilities/functions.sass
+++ b/assets/styles/bulma/utilities/functions.sass
@@ -58,7 +58,7 @@
       $value: $value * $number
   @else if $exp < 0
     @for $i from 1 through -$exp
-      $value: $value / $number
+      $value: divide($value, $number)
   @return $value
 
 @function colorLuminance($color)
@@ -67,11 +67,11 @@
   $color-rgb: ('red': red($color),'green': green($color),'blue': blue($color))
   @each $name, $value in $color-rgb
     $adjusted: 0
-    $value: $value / 255
+    $value: divide($value, 255)
     @if $value < 0.03928
-      $value: $value / 12.92
+      $value: divide($value, 12.92)
     @else
-      $value: ($value + .055) / 1.055
+      $value: divide(($value + .055), 1.055)
       $value: powerNumber($value, 2)
     $color-rgb: map-merge($color-rgb, ($name: $value))
   @return (map-get($color-rgb, 'red') * .2126) + (map-get($color-rgb, 'green') * .7152) + (map-get($color-rgb, 'blue') * .0722)
@@ -82,7 +82,7 @@
   @else
     @return #fff
 
-@function findLightColor($color)
+@function findLightColor($color, $l: 96%)
   @if type-of($color) == 'color'
     $l: 96%
     @if lightness($color) > 96%
@@ -90,9 +90,8 @@
     @return change-color($color, $lightness: $l)
   @return $background
 
-@function findDarkColor($color)
+@function findDarkColor($color, $base-l: 29%)
   @if type-of($color) == 'color'
-    $base-l: 29%
     $luminance: colorLuminance($color)
     $luminance-delta: (0.53 - $luminance)
     $target-l: round($base-l + ($luminance-delta * 53))
@@ -113,3 +112,24 @@
   @if type-of($color) != 'color'
     @return $color
   @return lighten($color, $amount)
+
+// Custom divide function by @mdo from https://github.com/twbs/bootstrap/pull/34245
+// Replaces old slash division deprecated in Dart Sass
+@function divide($dividend, $divisor, $precision: 10)
+  $sign: if($dividend > 0 and $divisor > 0, 1, -1)
+  $dividend: abs($dividend)
+  $divisor: abs($divisor)
+  $quotient: 0
+  $remainder: $dividend
+  @if $dividend == 0
+    @return 0
+  @if $divisor == 0
+    @error "Cannot divide by 0"
+  @if $divisor == 1
+    @return $dividend
+  @while $remainder >= $divisor
+    $quotient: $quotient + 1
+    $remainder: $remainder - $divisor
+  @if $remainder > 0 and $precision > 0
+    $remainder: divide($remainder * 10, $divisor, $precision - 1) * .1
+  @return ($quotient + $remainder) * $sign

--- a/assets/styles/bulma/utilities/initial-variables.sass
+++ b/assets/styles/bulma/utilities/initial-variables.sass
@@ -16,11 +16,11 @@ $white-bis:    hsl(0, 0%, 98%) !default
 $white:        hsl(0, 0%, 100%) !default
 
 $orange:       hsl(14,  100%, 53%) !default
-$yellow:       hsl(48,  100%, 67%) !default
-$green:        hsl(141, 53%,  53%) !default
+$yellow:       hsl(44,  100%, 77%) !default
+$green:        hsl(153, 53%,  53%) !default
 $turquoise:    hsl(171, 100%, 41%) !default
-$cyan:         hsl(204, 71%,  53%) !default
-$blue:         hsl(217, 71%,  53%) !default
+$cyan:         hsl(207, 61%,  53%) !default
+$blue:         hsl(229, 53%,  53%) !default
 $purple:       hsl(271, 100%, 71%) !default
 $red:          hsl(348, 86%, 61%) !default
 
@@ -62,6 +62,7 @@ $widescreen-enabled: true !default
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * $gap) !default
 $fullhd-enabled: true !default
+$breakpoints: ("mobile": ("until": $tablet), "tablet": ("from": $tablet), "tablet-only": ("from": $tablet, "until": $desktop), "touch": ("from": $desktop), "desktop": ("from": $desktop), "desktop-only": ("from": $desktop, "until": $widescreen), "until-widescreen": ("until": $widescreen), "widescreen": ("from": $widescreen), "widescreen-only": ("from": $widescreen, "until": $fullhd), "until-fullhd": ("until": $fullhd), "fullhd": ("from": $fullhd)) !default
 
 // Miscellaneous
 
@@ -69,7 +70,7 @@ $easing: ease-out !default
 $radius-small: 2px !default
 $radius: 4px !default
 $radius-large: 6px !default
-$radius-rounded: 290486px !default
+$radius-rounded: 9999px !default
 $speed: 86ms !default
 
 // Flags

--- a/assets/styles/bulma/utilities/mixins.sass
+++ b/assets/styles/bulma/utilities/mixins.sass
@@ -9,11 +9,11 @@
 =center($width, $height: 0)
   position: absolute
   @if $height != 0
-    left: calc(50% - (#{$width} / 2))
-    top: calc(50% - (#{$height} / 2))
+    left: calc(50% - (#{$width} * 0.5))
+    top: calc(50% - (#{$height} * 0.5))
   @else
-    left: calc(50% - (#{$width} / 2))
-    top: calc(50% - (#{$width} / 2))
+    left: calc(50% - (#{$width} * 0.5))
+    top: calc(50% - (#{$width} * 0.5))
 
 =fa($size, $dimensions)
   display: inline-block
@@ -25,6 +25,11 @@
   width: $dimensions
 
 =hamburger($dimensions)
+  -moz-appearance: none
+  -webkit-appearance: none
+  appearance: none
+  background: none
+  border: none
   cursor: pointer
   display: block
   height: $dimensions
@@ -68,6 +73,18 @@
     &:#{$placeholder}-placeholder
       @content
 
+=reset
+  -moz-appearance: none
+  -webkit-appearance: none
+  appearance: none
+  background: none
+  border: none
+  color: currentColor
+  font-family: inherit
+  font-size: 1em
+  margin: 0
+  padding: 0
+
 // Responsiveness
 
 =from($device)
@@ -76,6 +93,10 @@
 
 =until($device)
   @media screen and (max-width: $device - 1px)
+    @content
+
+=between($from, $until)
+  @media screen and (min-width: $from) and (max-width: $until - 1px)
     @content
 
 =mobile
@@ -127,6 +148,21 @@
   @if $fullhd-enabled
     @media screen and (min-width: $fullhd)
       @content
+
+=breakpoint($name)
+  $breakpoint: map-get($breakpoints, $name)
+  @if $breakpoint
+    $from: map-get($breakpoint, "from")
+    $until: map-get($breakpoint, "until")
+    @if $from and $until
+      +between($from, $until)
+        @content
+    @else if $from
+      +from($from)
+        @content
+    @else if $until
+      +until($until)
+        @content
 
 =ltr
   @if not $rtl
@@ -265,4 +301,3 @@
   position: absolute
   right: $offset
   top: $offset
-


### PR DESCRIPTION
This updates the Bulma version used by the project to revision [`514229c985e0146039d6960a220f317876c39f8d`](https://github.com/jgthms/bulma/tree/514229c985e0146039d6960a220f317876c39f8d).

This changes the color scheme slightly as it now uses slightly more muted colors:

![image](https://user-images.githubusercontent.com/9332912/187039518-88d2d1ae-0733-4643-bc79-22be60e7bbc5.png)
