### PR TITLE
Quirks Mode no more!

### DIFF
--- a/src/server/views/html/mod.rs
+++ b/src/server/views/html/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use hyper::header::CONTENT_TYPE;
 use hyper::{Body, Response};
-use maud::{html, Markup, Render};
+use maud::{DOCTYPE, html, Markup, Render};
 
 pub mod error;
 pub mod index;
@@ -13,6 +13,7 @@ use crate::server::SELF_BASE_URL;
 
 fn render_html<B: Render>(title: &str, body: B) -> Response<Body> {
     let rendered = html! {
+        (DOCTYPE)
         html {
             head {
                 meta charset="utf-8";

--- a/src/server/views/html/mod.rs
+++ b/src/server/views/html/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use hyper::header::CONTENT_TYPE;
 use hyper::{Body, Response};
-use maud::{DOCTYPE, html, Markup, Render};
+use maud::{html, Markup, Render, DOCTYPE};
 
 pub mod error;
 pub mod index;


### PR DESCRIPTION
Until now, we served all HTML documents in [Quirks Mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) which solely exists for backwards-compatibility with web pages from the age of Netscape Navigator 4 and IE 5.

I suppose we don't want that, which is why I fixed this by setting the proper `<!DOCTYPE html>` in all served pages.