### PR TITLE
Allow analyzing crates in sub-directories of repo root

### DIFF
--- a/assets/links.js
+++ b/assets/links.js
@@ -7,8 +7,8 @@ function buildRepoLink() {
     let innerPath = formRef.elements["innerPath"].value;
 
     let qparams = "";
-    if (innerPath.length != 0) {
-        qparams = "?path=" + innerPath;
+    if (innerPath.length > 0) {
+        qparams = "?path=" + encodeURIComponent(innerPath);
     }
 
     if (hoster === "gitea") {

--- a/assets/links.js
+++ b/assets/links.js
@@ -4,6 +4,12 @@ function buildRepoLink() {
     let hoster = formRef.elements["hosterSelect"].value.toLowerCase();
     let owner = formRef.elements["owner"].value;
     let repoName = formRef.elements["repoName"].value;
+    let innerPath = formRef.elements["innerPath"].value;
+
+    let qparams = "";
+    if (innerPath.length != 0) {
+        qparams = "?path=" + innerPath;
+    }
 
     if (hoster === "gitea") {
         let baseUrl = formRef.elements["baseUrl"].value;
@@ -18,9 +24,9 @@ function buildRepoLink() {
             return;
         }
 
-        window.location.href = `/repo/${hoster}/${baseUrl}/${owner}/${repoName}`;
+        window.location.assign(`/repo/${hoster}/${baseUrl}/${owner}/${repoName}${qparams}`);
     } else {
-        window.location.href = `/repo/${hoster}/${owner}/${repoName}`;
+        window.location.assign(`/repo/${hoster}/${owner}/${repoName}${qparams}`);
     }
 }
 
@@ -32,8 +38,8 @@ function buildCrateLink() {
 
     if (crateVer.length == 0) {
         // default to latest version
-        window.location.href = `/crate/${crate}`;
+        window.location.assign(`/crate/${crate}`);
     } else {
-        window.location.href = `/crate/${crate}/${crateVer}`;
+        window.location.assign(`/crate/${crate}/${crateVer}`);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -409,7 +409,7 @@ impl ExtraConfig {
         struct ExtraConfigPartial {
             style: Option<BadgeStyle>,
             compact: Option<bool>,
-            path: Option<String>
+            path: Option<String>,
         }
 
         let extra_config = qs

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -359,7 +359,9 @@ impl App {
     ) -> Response<Body> {
         match format {
             StatusFormat::Svg => views::badge::response(analysis_outcome.as_ref(), badge_knobs),
-            StatusFormat::Html => views::html::status::render(analysis_outcome, subject_path, badge_knobs),
+            StatusFormat::Html => {
+                views::html::status::render(analysis_outcome, subject_path, badge_knobs)
+            }
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -359,7 +359,7 @@ impl App {
     ) -> Response<Body> {
         match format {
             StatusFormat::Svg => views::badge::response(analysis_outcome.as_ref(), badge_knobs),
-            StatusFormat::Html => views::html::status::render(analysis_outcome, subject_path),
+            StatusFormat::Html => views::html::status::render(analysis_outcome, subject_path, badge_knobs),
         }
     }
 

--- a/src/server/views/badge.rs
+++ b/src/server/views/badge.rs
@@ -3,11 +3,11 @@ use hyper::header::CONTENT_TYPE;
 use hyper::{Body, Response};
 
 use crate::engine::AnalyzeDependenciesOutcome;
-use crate::server::BadgeKnobs;
+use crate::server::ExtraConfig;
 
 pub fn badge(
     analysis_outcome: Option<&AnalyzeDependenciesOutcome>,
-    badge_knobs: BadgeKnobs,
+    badge_knobs: ExtraConfig,
 ) -> Badge {
     let subject = if badge_knobs.compact {
         "deps"
@@ -74,7 +74,7 @@ pub fn badge(
 
 pub fn response(
     analysis_outcome: Option<&AnalyzeDependenciesOutcome>,
-    badge_knobs: BadgeKnobs,
+    badge_knobs: ExtraConfig,
 ) -> Response<Body> {
     let badge = badge(analysis_outcome, badge_knobs).to_svg();
 

--- a/src/server/views/html/index.rs
+++ b/src/server/views/html/index.rs
@@ -57,6 +57,16 @@ fn link_forms() -> Markup {
                             p class="help" id="baseUrlHelp" { "Base URL of the Git instance the project is hosted on. Only relevant for Gitea Instances." }
                         }
 
+                        div class="field" {
+                            label class="label" { "Path in Repository" }
+
+                            div class="control" {
+                                input class="input" type="text" id="innerPath" placeholder="project1/rust-stuff";
+                            }
+
+                            p class="help" id="baseUrlHelp" { "Path within the repository where the " code { "Cargo.toml" } " file is located." }
+                        }
+
                         input type="submit" class="button is-primary" value="Check" onclick="buildRepoLink();";
                     }
                 }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -349,7 +349,7 @@ fn render_failure(subject_path: SubjectPath) -> Markup {
 fn render_success(
     analysis_outcome: AnalyzeDependenciesOutcome,
     subject_path: SubjectPath,
-    extra_config: ExtraConfig
+    extra_config: ExtraConfig,
 ) -> Markup {
     let self_path = match subject_path {
         SubjectPath::Repo(ref repo_path) => format!(
@@ -378,7 +378,11 @@ fn render_success(
     // NOTE(feliix42): While we could encode the whole `ExtraConfig` struct here, I've decided
     // against doing so as this would always append the defaults for badge style and compactness
     // settings to the URL, bloating it unnecessarily, we can do that once it's needed.
-    let options = serde_urlencoded::to_string([("path", extra_config.path.clone().unwrap_or_default().as_str())]).unwrap();
+    let options = serde_urlencoded::to_string([(
+        "path",
+        extra_config.path.clone().unwrap_or_default().as_str(),
+    )])
+    .unwrap();
 
     html! {
         section class=(format!("hero {}", hero_class)) {
@@ -391,7 +395,7 @@ fn render_success(
 
                     @if let Some(ref path) = extra_config.path {
                         p class="subtitle" {
-                            (render_path(&path))
+                            (render_path(path))
                         }
                     }
 

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -11,7 +11,7 @@ use crate::models::crates::{AnalyzedDependencies, AnalyzedDependency, CrateName}
 use crate::models::repo::RepoSite;
 use crate::models::SubjectPath;
 use crate::server::views::badge;
-use crate::server::BadgeKnobs;
+use crate::server::ExtraConfig;
 
 fn get_crates_url(name: impl AsRef<str>) -> String {
     format!("https://crates.io/crates/{}", name.as_ref())
@@ -347,7 +347,7 @@ fn render_success(
     let status_base_url = format!("{}/{}", &super::SELF_BASE_URL as &str, self_path);
 
     let status_data_uri =
-        badge::badge(Some(&analysis_outcome), BadgeKnobs::default()).to_svg_data_uri();
+        badge::badge(Some(&analysis_outcome), ExtraConfig::default()).to_svg_data_uri();
 
     let hero_class = if analysis_outcome.any_always_insecure() {
         "is-danger"

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -375,6 +375,11 @@ fn render_success(
         "is-success"
     };
 
+    // NOTE(feliix42): While we could encode the whole `ExtraConfig` struct here, I've decided
+    // against doing so as this would always append the defaults for badge style and compactness
+    // settings to the URL, bloating it unnecessarily, we can do that once it's needed.
+    let options = serde_urlencoded::to_string([("path", extra_config.path.clone().unwrap_or_default().as_str())]).unwrap();
+
     html! {
         section class=(format!("hero {}", hero_class)) {
             div class="hero-head" { (super::render_navbar()) }
@@ -384,7 +389,7 @@ fn render_success(
                         (render_title(&subject_path))
                     }
 
-                    @if let Some(path) = extra_config.path {
+                    @if let Some(ref path) = extra_config.path {
                         p class="subtitle" {
                             (render_path(&path))
                         }
@@ -396,7 +401,11 @@ fn render_success(
             div class="hero-footer" {
                 div class="container" {
                     pre class="is-size-7" {
-                        (format!("[![dependency status]({}/status.svg)]({})", status_base_url, status_base_url))
+                        @if extra_config.path.is_some() {
+                            (format!("[![dependency status]({}/status.svg?{opt})]({}?{opt})", status_base_url, status_base_url, opt = options))
+                        } @else {
+                            (format!("[![dependency status]({}/status.svg)]({})", status_base_url, status_base_url))
+                        }
                     }
                 }
             }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -161,6 +161,23 @@ fn render_title(subject_path: &SubjectPath) -> Markup {
     }
 }
 
+/// Renders a path within a repository as HTML.
+///
+/// Panics, when the string is empty.
+fn render_path(inner_path: &str) -> Markup {
+    let path_icon = PreEscaped(fa(FaType::Regular, "folder-open").unwrap());
+
+    let mut splitted = inner_path.trim_matches('/').split('/');
+    let init = splitted.next().unwrap().to_string();
+    let path_spaced = splitted.fold(init, |b, val| b + " / " + val);
+
+    html! {
+        { (path_icon) }
+        " / "
+        (path_spaced)
+    }
+}
+
 fn dependencies_pluralized(count: usize) -> &'static str {
     if count == 1 {
         "dependency"
@@ -332,6 +349,7 @@ fn render_failure(subject_path: SubjectPath) -> Markup {
 fn render_success(
     analysis_outcome: AnalyzeDependenciesOutcome,
     subject_path: SubjectPath,
+    extra_config: ExtraConfig
 ) -> Markup {
     let self_path = match subject_path {
         SubjectPath::Repo(ref repo_path) => format!(
@@ -347,7 +365,7 @@ fn render_success(
     let status_base_url = format!("{}/{}", &super::SELF_BASE_URL as &str, self_path);
 
     let status_data_uri =
-        badge::badge(Some(&analysis_outcome), ExtraConfig::default()).to_svg_data_uri();
+        badge::badge(Some(&analysis_outcome), extra_config.clone()).to_svg_data_uri();
 
     let hero_class = if analysis_outcome.any_always_insecure() {
         "is-danger"
@@ -364,6 +382,12 @@ fn render_success(
                 div class="container" {
                     h1 class="title is-1" {
                         (render_title(&subject_path))
+                    }
+
+                    @if let Some(path) = extra_config.path {
+                        p class="subtitle" {
+                            (render_path(&path))
+                        }
                     }
 
                     img src=(status_data_uri);
@@ -416,6 +440,7 @@ fn render_success(
 pub fn render(
     analysis_outcome: Option<AnalyzeDependenciesOutcome>,
     subject_path: SubjectPath,
+    extra_config: ExtraConfig,
 ) -> Response<Body> {
     let title = match subject_path {
         SubjectPath::Repo(ref repo_path) => {
@@ -427,7 +452,7 @@ pub fn render(
     };
 
     if let Some(outcome) = analysis_outcome {
-        super::render_html(&title, render_success(outcome, subject_path))
+        super::render_html(&title, render_success(outcome, subject_path, extra_config))
     } else {
         super::render_html(&title, render_failure(subject_path))
     }


### PR DESCRIPTION
## Description

This PR will allow people to analyze crates that do not live in the root of a repository.
The main work for that had already been done, convenience functions were already in place for constructing links referring to sub-directory.
Hence, these are the main changes:

- update parser and scheme for Query Parameters (that were so far only used to describe Badge Styling)
- adjust the link generator to generate the new links accordingly.
- make the directory structure location visible in the report
- update svg link generation to reflect possible sub-directory structures

This will close #95.

The chosen link scheme looks as follows:
```
https://deps.rs/repo/<HOSTER>/<USER>/<REPO>?path=[...]
```
I do realize that this could've been done with a `/<PATH>` argument instead but I thought that this is a bit cleaner, especially keeping in mind #12 which could then be solved by another parameter for the branch/commit, reducing bloat in the URL.

Example: `http://localhost:8080/repo/github/cldfire/minecraft-status?path=rust`

![image](https://user-images.githubusercontent.com/9332912/187797404-458639e2-afcf-4447-8f8f-160d76df8abd.png)


## TODOs
- [x] allow analyzing crates in sub-directories
- [x] adjust the link generator
- [x] update SVG links
- [x] highlight the directory structure using breadcrumbs
- [x] Run `cargo clippy -D warnings` and `cargo fmt`