### PR TITLE
Point the livenessProbe at /repo/github/deps-rs/deps.rs

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -26,7 +26,9 @@ spec:
           volumeMounts:
             - mountPath: /home/deps/.cargo
               name: cargo
-          readinessProbe:
+          livenessProbe:
             httpGet:
               path: /repo/github/deps-rs/deps.rs
               port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           volumeMounts:
             - mountPath: /home/deps/.cargo
               name: cargo
-          readynessProbe:
+          readinessProbe:
             httpGet:
               path: /
               port: 8080

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -28,5 +28,5 @@ spec:
               name: cargo
           readinessProbe:
             httpGet:
-              path: /
+              path: /repo/github/deps-rs/deps.rs
               port: 8080

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -26,6 +26,10 @@ spec:
           volumeMounts:
             - mountPath: /home/deps/.cargo
               name: cargo
+          readynessProbe:
+            httpGet:
+              path: /
+              port: 8080
           livenessProbe:
             httpGet:
               path: /repo/github/deps-rs/deps.rs


### PR DESCRIPTION
Would this be ok for you as a way of detecting when GitHub starts timing out and making it restart the server?
If so I'll have to change that page because we currently seem to reply with a 200 even when there's an error.