### PR TITLE
Tweak cache durations

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -56,20 +56,20 @@ impl Engine {
         );
         let get_popular_crates = Cache::new(
             GetPopularCrates::new(client.clone()),
-            Duration::from_secs(120),
+            Duration::from_secs(15 * 60),
             1,
             logger.clone(),
         );
         let get_popular_repos = Cache::new(
             GetPopularRepos::new(client.clone()),
-            Duration::from_secs(120),
+            Duration::from_secs(5 * 60),
             1,
             logger.clone(),
         );
         let retrieve_file_at_path = RetrieveFileAtPath::new(client.clone());
         let fetch_advisory_db = Cache::new(
             FetchAdvisoryDatabase::new(client),
-            Duration::from_secs(1800),
+            Duration::from_secs(30 * 60),
             1,
             logger,
         );


### PR DESCRIPTION
Query crate from the local crates.io index clone: **10s** (unchaged)
Get popular crates from crates.io: **2m -> 15m**
Get popular repos from github: **2m -> 5m**
Fetch advisory db: **30m** (unchanged)