### PR TITLE
Read Cargo.lock for repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
+ "petgraph",
  "semver",
  "serde",
  "toml",
@@ -292,6 +293,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -860,6 +867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1249,7 @@ dependencies = [
  "anyhow",
  "badge",
  "cadence",
+ "cargo-lock",
  "crates-index",
  "derive_more",
  "font-awesome-as-a-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ badge = { path = "./libs/badge" }
 
 anyhow = "1"
 cadence = "0.29"
+cargo-lock = { version = "8.0.3", features = ["dependency-tree"] }
 crates-index = "0.18"
 derive_more = "0.99"
 font-awesome-as-a-crate = "0.3"

--- a/src/engine/fut/crawl.rs
+++ b/src/engine/fut/crawl.rs
@@ -18,25 +18,25 @@ pub async fn crawl_manifest(
     let mut futures: FuturesOrdered<BoxFuture<'static, Result<(RelativePathBuf, String), Error>>> =
         FuturesOrdered::new();
 
+    // cargo toml
     let engine2 = engine.clone();
     let repo_path2 = repo_path.clone();
+    let entry_point2 = entry_point.clone();
 
     let fut = async move {
         let contents = engine2
-            .retrieve_manifest_at_path(&repo_path2, &entry_point)
+            .retrieve_manifest_at_path(&repo_path2, &entry_point2)
             .await?;
-        Ok((entry_point, contents))
+        Ok((entry_point2, contents))
     }
     .boxed();
 
     futures.push_back(fut);
 
+    // cargo toml: paths_of_interest
     while let Some(item) = futures.next().await {
         let (path, raw_manifest) = item?;
         let output = crawler.step(path, raw_manifest)?;
-
-        let engine = engine.clone();
-        let repo_path = repo_path.clone();
 
         for path in output.paths_of_interest {
             let engine = engine.clone();
@@ -52,5 +52,17 @@ pub async fn crawl_manifest(
         }
     }
 
+    // cargo lock
+    let engine3 = engine.clone();
+    let repo_path3 = repo_path.clone();
+    let entry_point3 = entry_point.clone();
+    
+    let contents = engine3
+        .retrieve_lock_at_path(&repo_path3, &entry_point3)
+        .await;
+    if contents.is_ok() {
+        _ = crawler.process_lock(entry_point3, contents.unwrap());
+    }
+   
     Ok(crawler.finalize())
 }

--- a/src/models/crates.rs
+++ b/src/models/crates.rs
@@ -83,6 +83,7 @@ pub struct CrateDeps {
     pub main: IndexMap<CrateName, CrateDep>,
     pub dev: IndexMap<CrateName, CrateDep>,
     pub build: IndexMap<CrateName, CrateDep>,
+    pub unknown: IndexMap<CrateName, CrateDep>
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
If the Cargo.lock is available in the repo, let's use it. 
Related to #26. 