### PR TITLE
Add Gitlab custom domains (self-hosted) repo model.

### DIFF
--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -125,7 +125,7 @@ fn dependency_table(title: &str, deps: &IndexMap<CrateName, AnalyzedDependency>)
 fn get_site_icon(site: &RepoSite) -> (FaType, &'static str) {
     match *site {
         RepoSite::Github => (FaType::Brands, "github"),
-        RepoSite::Gitlab => (FaType::Brands, "gitlab"),
+        RepoSite::Gitlab(_) => (FaType::Brands, "gitlab"),
         RepoSite::Bitbucket => (FaType::Brands, "bitbucket"),
         // FIXME: There is no brands/{sourcehut, codeberg, gitea} icon, so just use an
         // icon which looks close enough.


### PR DESCRIPTION
This PR adds the ability to check repositories on self-hosted gitlab instances. 

(just a quick little addition, I am happy to rename the GiteaDomain type for something more fitting, just short on time right now)

The way this works is that it one can now put the gitlab instance hostname into the url just like it works with the gitea implementation. For this to work the repository has to be publicly accessible of course.

I guess this also somewhat addresses #84 