### PR TITLE
refactor: drop unused `cadence` metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,15 +471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cadence"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
-dependencies = [
- "crossbeam-channel",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,7 +3566,6 @@ dependencies = [
  "actix-web-lab",
  "anyhow",
  "badge",
- "cadence",
  "crates-index",
  "derive_more 1.0.0",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ badge = { path = "./libs/badge" }
 actix-web = "4"
 actix-web-lab = "0.23"
 anyhow = "1"
-cadence = "1"
 crates-index = { version = "3", default-features = false, features = ["git"] }
 derive_more = { version = "1", features = ["display", "error", "from"] }
 dotenvy = "0.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,13 @@
 #![deny(rust_2018_idioms)]
 #![warn(missing_debug_implementations)]
 
-use std::{
-    env,
-    net::{Ipv4Addr, UdpSocket},
-    time::Duration,
-};
+use std::{env, net::Ipv4Addr, time::Duration};
 
 use actix_web::{
     middleware::Logger,
     web::{self, ThinData},
 };
 use actix_web_lab::middleware::NormalizePath;
-use cadence::{QueuingMetricSink, UdpMetricSink};
 use reqwest::redirect::Policy as RedirectPolicy;
 
 mod engine;
@@ -25,14 +20,6 @@ mod utils;
 use self::{engine::Engine, utils::index::ManagedIndex};
 
 const DEPS_RS_UA: &str = "deps.rs";
-
-fn init_metrics() -> QueuingMetricSink {
-    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    socket.set_nonblocking(true).unwrap();
-    let host = ("127.0.0.1", 8125);
-    let sink = UdpMetricSink::from(host, socket).unwrap();
-    QueuingMetricSink::from(sink)
-}
 
 fn init_tracing_subscriber() {
     use tracing::level_filters::LevelFilter;
@@ -57,7 +44,6 @@ fn init_tracing_subscriber() {
 async fn main() {
     dotenvy::dotenv().ok();
     init_tracing_subscriber();
-    let metrics = init_metrics();
 
     let client = reqwest::Client::builder()
         .user_agent(DEPS_RS_UA)
@@ -81,8 +67,7 @@ async fn main() {
         });
     }
 
-    let mut engine = Engine::new(client.clone(), index);
-    engine.set_metrics(metrics);
+    let engine = Engine::new(client.clone(), index);
 
     let server = actix_web::HttpServer::new(move || {
         actix_web::App::new()


### PR DESCRIPTION
I've always wandered what is was for. Nothing :smile:.