### PR TITLE
fix: filter out yanked releases in engine

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -238,6 +238,7 @@ impl Engine {
             .releases
             .iter()
             .filter(|release| req.matches(&release.version))
+            .filter(|release| !release.yanked)
             .max_by(|r1, r2| r1.version.cmp(&r2.version))
             .cloned();
 


### PR DESCRIPTION
### What’s Changed

- Updated the `Engine::find_latest_stable_crate_release` method to filter out yanked releases.
  - Now, only the latest **non-yanked** version will be selected for redirection.
  - If all versions are yanked, the method returns `None`, resulting in a 404 or CrateFetchFailed error upstream.

### Related Issue

- Close [Issue #256](https://github.com/deps-rs/deps.rs/issues/256)

### Motivation

Previously, the `/crate/{crate_name}` route would redirect to the latest version, even if it was yanked. This behavior is inconsistent with crates.io, docs.rs, and other Rust ecosystem tools, and may mislead users into using yanked (unrecommended) versions. With this change, only non-yanked versions are considered for redirection, aligning with community expectations.

### How to Test

1. Run the project locally with `cargo run`.
2. Visit [http://localhost:8080/crate/cargo-chef](http://localhost:8080/crate/cargo-chef) in your browser.
   - If the latest version is yanked, you should be redirected to the latest **non-yanked** version.
   - If all versions are yanked, you should see a 404 or an appropriate error.