### PR TITLE
Reduce `actix-web*` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ dependencies = [
  "actix-utils",
  "base64",
  "bitflags",
- "brotli",
  "bytes",
  "bytestring",
  "derive_more",
@@ -154,7 +153,6 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
  "derive_more",
  "encoding_rs",
  "foldhash",
@@ -202,7 +200,6 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "actix-web-lab-derive",
  "ahash",
  "arc-swap",
  "bytes",
@@ -227,16 +224,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "actix-web-lab-derive"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd80fa0bd6217e482112d9d87a05af8e0f8dec9e3aa51f34816f761c5cf7da7"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -274,21 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -411,27 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,17 +485,6 @@ name = "codemap"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
-
-[[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
 
 [[package]]
 name = "core-foundation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 badge = { path = "./libs/badge" }
 
-actix-web = "4"
-actix-web-lab = "0.24"
+actix-web = { version = "4", default-features = false, features = ["macros", "compress-gzip", "compress-zstd", "http2", "unicode", "compat"] }
+actix-web-lab = { version = "0.24", default-features = false }
 anyhow = "1"
 crates-index = { version = "3", default-features = false, features = ["git", "git-https-reqwest"] }
 # to be kept in sync with the version used by `crates-index`


### PR DESCRIPTION
This disables the following features for actix-web:

1. `compress-brotli`: I usually disable this given that zstd has reached 71% global usage [^1]. brotli is also slow to compress.
2. `cookies`: we don't use them

And the `derive` feature of `actix-web-lab`, which we don't need.


[^1]: https://caniuse.com/zstd