### PR TITLE
chore(deps): update gix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7687b8ee7dbe040d1c07c8ccfa40d998f4d83424b680bc5ef349c0fbc5331b2c"
+checksum = "ed2cb0f9440838694b31ff3787148d329e02f03c16ff96c28790261563e82174"
 dependencies = [
- "gix 0.79.0",
+ "gix 0.83.0",
  "hex",
  "home",
  "memchr",
@@ -695,6 +695,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1003,8 +1017,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
 dependencies = [
  "gix-actor 0.38.0",
- "gix-attributes",
- "gix-command",
+ "gix-attributes 0.30.1",
+ "gix-command 0.7.1",
  "gix-commitgraph 0.32.0",
  "gix-config 0.51.0",
  "gix-credentials 0.35.0",
@@ -1012,91 +1026,99 @@ dependencies = [
  "gix-diff 0.58.0",
  "gix-discover 0.46.0",
  "gix-error 0.0.0",
- "gix-features",
+ "gix-features 0.46.1",
  "gix-filter 0.25.0",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
+ "gix-fs 0.19.1",
+ "gix-glob 0.24.0",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-ignore 0.19.0",
  "gix-index 0.46.0",
- "gix-lock",
+ "gix-lock 21.0.1",
  "gix-negotiate 0.26.0",
  "gix-object 0.55.0",
  "gix-odb 0.75.0",
  "gix-pack 0.65.0",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
+ "gix-path 0.11.1",
+ "gix-pathspec 0.15.1",
+ "gix-prompt 0.13.1",
  "gix-protocol 0.56.0",
  "gix-ref 0.58.0",
  "gix-refspec 0.36.0",
  "gix-revision 0.40.0",
  "gix-revwalk 0.26.0",
- "gix-sec",
- "gix-shallow",
+ "gix-sec 0.13.1",
+ "gix-shallow 0.8.1",
  "gix-submodule 0.25.0",
- "gix-tempfile",
+ "gix-tempfile 21.0.1",
  "gix-trace",
  "gix-transport 0.53.0",
  "gix-traverse 0.52.0",
- "gix-url",
+ "gix-url 0.35.2",
  "gix-utils",
  "gix-validate",
  "gix-worktree 0.47.0",
- "gix-worktree-state",
+ "gix-worktree-state 0.25.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix"
-version = "0.79.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66adef5e4d836ad08bf424dce5e3eb18f51544eee702860419295120dd48811"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
 dependencies = [
- "gix-actor 0.39.0",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph 0.33.0",
- "gix-config 0.52.0",
- "gix-credentials 0.36.0",
- "gix-date 0.14.0",
- "gix-diff 0.59.0",
- "gix-discover 0.47.0",
- "gix-error 0.1.0",
- "gix-features",
- "gix-filter 0.26.0",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index 0.47.0",
- "gix-lock",
- "gix-negotiate 0.27.0",
- "gix-object 0.56.0",
- "gix-odb 0.76.0",
- "gix-pack 0.66.0",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
- "gix-protocol 0.57.0",
- "gix-ref 0.59.0",
- "gix-refspec 0.37.0",
- "gix-revision 0.41.0",
- "gix-revwalk 0.27.0",
- "gix-sec",
- "gix-shallow",
- "gix-submodule 0.26.0",
- "gix-tempfile",
+ "gix-actor 0.41.0",
+ "gix-archive",
+ "gix-attributes 0.33.0",
+ "gix-blame",
+ "gix-command 0.9.0",
+ "gix-commitgraph 0.37.0",
+ "gix-config 0.56.0",
+ "gix-credentials 0.38.0",
+ "gix-date 0.15.3",
+ "gix-diff 0.63.0",
+ "gix-dir",
+ "gix-discover 0.51.0",
+ "gix-error 0.2.3",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-lock 23.0.0",
+ "gix-merge",
+ "gix-negotiate 0.31.0",
+ "gix-object 0.60.0",
+ "gix-odb 0.80.0",
+ "gix-pack 0.70.0",
+ "gix-path 0.12.0",
+ "gix-pathspec 0.18.0",
+ "gix-prompt 0.15.0",
+ "gix-protocol 0.61.0",
+ "gix-ref 0.63.0",
+ "gix-refspec 0.41.0",
+ "gix-revision 0.45.0",
+ "gix-revwalk 0.31.0",
+ "gix-sec 0.14.0",
+ "gix-shallow 0.12.0",
+ "gix-status",
+ "gix-submodule 0.30.0",
+ "gix-tempfile 23.0.0",
  "gix-trace",
- "gix-transport 0.54.0",
- "gix-traverse 0.53.0",
- "gix-url",
+ "gix-transport 0.57.0",
+ "gix-traverse 0.57.0",
+ "gix-url 0.36.0",
  "gix-utils",
  "gix-validate",
- "gix-worktree 0.48.0",
+ "gix-worktree 0.52.0",
+ "gix-worktree-state 0.30.0",
+ "gix-worktree-stream",
+ "nonempty",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1117,14 +1139,26 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c44f13049925e8dc3955c20ecec5391cedfb041e0952416b583ecc57bc68325"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
 dependencies = [
  "bstr",
- "gix-date 0.14.0",
- "gix-error 0.1.0",
- "winnow 0.7.15",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-object 0.60.0",
+ "gix-worktree-stream",
 ]
 
 [[package]]
@@ -1134,9 +1168,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e72da5a1c35c9a129be0c60ab9968779981ca50835dd98650ecd8b0ea4d721e"
 dependencies = [
  "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
+ "gix-glob 0.24.0",
+ "gix-path 0.11.1",
+ "gix-quote 0.6.2",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+dependencies = [
+ "bstr",
+ "gix-glob 0.26.0",
+ "gix-path 0.12.0",
+ "gix-quote 0.7.1",
  "gix-trace",
  "kstring",
  "smallvec",
@@ -1154,6 +1205,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error 0.2.3",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.3",
+ "gix-diff 0.63.0",
+ "gix-error 0.2.3",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
+ "gix-trace",
+ "gix-traverse 0.57.0",
+ "gix-worktree 0.52.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-chunk"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,11 +1244,11 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14ee09ab454481a91fe969ca5afbd41c8a9b05680197b6554ebb69bdcf7d571"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
 dependencies = [
- "gix-error 0.1.0",
+ "gix-error 0.2.3",
 ]
 
 [[package]]
@@ -1178,8 +1258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
 dependencies = [
  "bstr",
- "gix-path",
- "gix-quote",
+ "gix-path 0.11.1",
+ "gix-quote 0.6.2",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+dependencies = [
+ "bstr",
+ "gix-path 0.12.0",
+ "gix-quote 0.7.1",
  "gix-trace",
  "shell-words",
 ]
@@ -1193,21 +1286,22 @@ dependencies = [
  "bstr",
  "gix-chunk 0.5.0",
  "gix-error 0.0.0",
- "gix-hash",
+ "gix-hash 0.22.1",
  "memmap2",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9dc2a550978b510b4e58b0bf5a15481433c3b21981330f3898d93f25b07d9a5"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
 dependencies = [
  "bstr",
- "gix-chunk 0.6.0",
- "gix-error 0.1.0",
- "gix-hash",
+ "gix-chunk 0.7.1",
+ "gix-error 0.2.3",
+ "gix-hash 0.25.0",
  "memmap2",
+ "nonempty",
 ]
 
 [[package]]
@@ -1217,12 +1311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a153dd4f5789fdf242e19e3f7105f2a114df198570225976fe4a108bac9dee4"
 dependencies = [
  "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
+ "gix-config-value 0.17.1",
+ "gix-features 0.46.1",
+ "gix-glob 0.24.0",
+ "gix-path 0.11.1",
  "gix-ref 0.58.0",
- "gix-sec",
+ "gix-sec 0.13.1",
  "memchr",
  "smallvec",
  "thiserror 2.0.18",
@@ -1232,22 +1326,20 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.52.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db778c8703f3c7f687e03ce22ac8f6eac02adbdafae4cb19d541126fa012524f"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref 0.59.0",
- "gix-sec",
- "memchr",
+ "gix-config-value 0.18.0",
+ "gix-features 0.48.0",
+ "gix-glob 0.26.0",
+ "gix-path 0.12.0",
+ "gix-ref 0.63.0",
+ "gix-sec 0.14.0",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1258,7 +1350,20 @@ checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-path",
+ "gix-path 0.11.1",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path 0.12.0",
  "libc",
  "thiserror 2.0.18",
 ]
@@ -1270,32 +1375,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
 dependencies = [
  "bstr",
- "gix-command",
- "gix-config-value",
+ "gix-command 0.7.1",
+ "gix-config-value 0.17.1",
  "gix-date 0.13.0",
- "gix-path",
- "gix-prompt",
- "gix-sec",
+ "gix-path 0.11.1",
+ "gix-prompt 0.13.1",
+ "gix-sec 0.13.1",
  "gix-trace",
- "gix-url",
+ "gix-url 0.35.2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b5ef8d1d86b9598df695fd61989e535dc7d139040ed9f31944bc7dcd81b713"
+checksum = "65ca11598b70811d7b16ff90945a6e57dfe521e85b744e51636965fe39cc8f60"
 dependencies = [
  "bstr",
- "gix-command",
- "gix-config-value",
- "gix-date 0.14.0",
- "gix-path",
- "gix-prompt",
- "gix-sec",
+ "gix-command 0.9.0",
+ "gix-config-value 0.18.0",
+ "gix-date 0.15.3",
+ "gix-path 0.12.0",
+ "gix-prompt 0.15.0",
+ "gix-sec 0.14.0",
  "gix-trace",
- "gix-url",
+ "gix-url 0.36.0",
  "thiserror 2.0.18",
 ]
 
@@ -1314,12 +1419,12 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66a5117b22495fe7cb4b443777cf3f024a1b1db0009771db440fc8b38a0a6fd"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
 dependencies = [
  "bstr",
- "gix-error 0.1.0",
+ "gix-error 0.2.3",
  "itoa",
  "jiff",
  "smallvec",
@@ -1332,20 +1437,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-object 0.55.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-diff"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee256b21a7d46cec85ab84e824742142a23a21111556a5e50c15796110c6c6"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
 dependencies = [
  "bstr",
- "gix-hash",
- "gix-object 0.56.0",
+ "gix-command 0.9.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-imara-diff",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-tempfile 23.0.0",
+ "gix-trace",
+ "gix-traverse 0.57.0",
+ "gix-worktree 0.52.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover 0.51.0",
+ "gix-fs 0.21.1",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-pathspec 0.18.0",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree 0.52.0",
  "thiserror 2.0.18",
 ]
 
@@ -1357,25 +1491,25 @@ checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs",
- "gix-path",
+ "gix-fs 0.19.1",
+ "gix-path 0.11.1",
  "gix-ref 0.58.0",
- "gix-sec",
+ "gix-sec 0.13.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.47.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93103d88576e048a681ebee83e93162972cd4cbce1485a6137cfc98fc0ba152d"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs",
- "gix-path",
- "gix-ref 0.59.0",
- "gix-sec",
+ "gix-fs 0.21.1",
+ "gix-path 0.12.0",
+ "gix-ref 0.63.0",
+ "gix-sec 0.14.0",
  "thiserror 2.0.18",
 ]
 
@@ -1390,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.1.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e37b10e97c822fc17550fc1a187283ad3ce79617e920bf179f301ee12abcbc"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
 dependencies = [
  "bstr",
 ]
@@ -1406,7 +1540,28 @@ dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path",
+ "gix-path 0.11.1",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path 0.12.0",
  "gix-trace",
  "gix-utils",
  "libc",
@@ -1426,13 +1581,13 @@ checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
+ "gix-attributes 0.30.1",
+ "gix-command 0.7.1",
+ "gix-hash 0.22.1",
  "gix-object 0.55.0",
  "gix-packetline",
- "gix-path",
- "gix-quote",
+ "gix-path 0.11.1",
+ "gix-quote 0.6.2",
  "gix-trace",
  "gix-utils",
  "smallvec",
@@ -1441,19 +1596,19 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094253121df9aa1cb46d1da0200dd63ebf16263a35f03295109978bf7ed2b483"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object 0.56.0",
+ "gix-attributes 0.33.0",
+ "gix-command 0.9.0",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
  "gix-packetline",
- "gix-path",
- "gix-quote",
+ "gix-path 0.12.0",
+ "gix-quote 0.7.1",
  "gix-trace",
  "gix-utils",
  "smallvec",
@@ -1468,8 +1623,22 @@ checksum = "de4bd0d8e6c6ef03485205f8eecc0359042a866d26dba569075db1ebcc005970"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features",
- "gix-path",
+ "gix-features 0.46.1",
+ "gix-path 0.11.1",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features 0.48.0",
+ "gix-path 0.12.0",
  "gix-utils",
  "thiserror 2.0.18",
 ]
@@ -1482,8 +1651,20 @@ checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-features",
- "gix-path",
+ "gix-features 0.46.1",
+ "gix-path 0.11.1",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features 0.48.0",
+ "gix-path 0.12.0",
 ]
 
 [[package]]
@@ -1493,7 +1674,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ced05d2d7b13bff08b2f7eb4e47cfeaf00b974c2ddce08377c4fe1f706b3eb"
 dependencies = [
  "faster-hex",
- "gix-features",
+ "gix-features 0.46.1",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+dependencies = [
+ "faster-hex",
+ "gix-features 0.48.0",
  "sha1-checked",
  "thiserror 2.0.18",
 ]
@@ -1504,7 +1697,18 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.22.1",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+dependencies = [
+ "gix-hash 0.25.0",
  "hashbrown 0.16.1",
  "parking_lot",
 ]
@@ -1516,10 +1720,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8953d87c13267e296d547f0fc7eaa8aa8fa5b2a9a34ab1cd5857f25240c7d299"
 dependencies = [
  "bstr",
- "gix-glob",
- "gix-path",
+ "gix-glob 0.24.0",
+ "gix-path 0.11.1",
  "gix-trace",
  "unicode-bom",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+dependencies = [
+ "bstr",
+ "gix-glob 0.26.0",
+ "gix-path 0.12.0",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1532,11 +1759,11 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
+ "gix-bitmap 0.2.16",
+ "gix-features 0.46.1",
+ "gix-fs 0.19.1",
+ "gix-hash 0.22.1",
+ "gix-lock 21.0.1",
  "gix-object 0.55.0",
  "gix-traverse 0.52.0",
  "gix-utils",
@@ -1552,21 +1779,21 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.47.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea450ed666a39676d7e9a41b899487d1645d88053bc8c8cecfca0cf96fcd4a03"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
 dependencies = [
  "bitflags",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object 0.56.0",
- "gix-traverse 0.53.0",
+ "gix-bitmap 0.3.1",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.0",
+ "gix-object 0.60.0",
+ "gix-traverse 0.57.0",
  "gix-utils",
  "gix-validate",
  "hashbrown 0.16.1",
@@ -1584,8 +1811,45 @@ version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbe09cf05ba7c679bba189acc29eeea137f643e7fff1b5dff879dfd45248be31"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 21.0.1",
  "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+dependencies = [
+ "gix-tempfile 23.0.0",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command 0.9.0",
+ "gix-diff 0.63.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-imara-diff",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-quote 0.7.1",
+ "gix-revision 0.45.0",
+ "gix-revwalk 0.31.0",
+ "gix-tempfile 23.0.0",
+ "gix-trace",
+ "gix-worktree 0.52.0",
+ "nonempty",
  "thiserror 2.0.18",
 ]
 
@@ -1598,7 +1862,7 @@ dependencies = [
  "bitflags",
  "gix-commitgraph 0.32.0",
  "gix-date 0.13.0",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-object 0.55.0",
  "gix-revwalk 0.26.0",
  "smallvec",
@@ -1607,18 +1871,16 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d01c3303ed336b72eb3a48543c028be4650279ff3c3b561f13fa9d2b1979e7"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
 dependencies = [
  "bitflags",
- "gix-commitgraph 0.33.0",
- "gix-date 0.14.0",
- "gix-hash",
- "gix-object 0.56.0",
- "gix-revwalk 0.27.0",
- "smallvec",
- "thiserror 2.0.18",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.3",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
 ]
 
 [[package]]
@@ -1630,10 +1892,10 @@ dependencies = [
  "bstr",
  "gix-actor 0.38.0",
  "gix-date 0.13.0",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
+ "gix-features 0.46.1",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-path 0.11.1",
  "gix-utils",
  "gix-validate",
  "itoa",
@@ -1644,23 +1906,21 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.56.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227e12fad42022ff08d6fbcc4bae34d6e2aa180576e9e1106d9a29a06798e750"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
 dependencies = [
  "bstr",
- "gix-actor 0.39.0",
- "gix-date 0.14.0",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
+ "gix-actor 0.41.0",
+ "gix-date 0.15.3",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1670,14 +1930,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d59882d2fdab5e609b0c452a6ef9a3bd12ef6b694be4f82ab8f126ad0969864"
 dependencies = [
  "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
+ "gix-features 0.46.1",
+ "gix-fs 0.19.1",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-object 0.55.0",
  "gix-pack 0.65.0",
- "gix-path",
- "gix-quote",
+ "gix-path 0.11.1",
+ "gix-quote 0.6.2",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -1685,19 +1945,20 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.76.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84f7e115b2b6615f0c5acddc269598ebc539c363fb276dbd242755a1dd7126c"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
 dependencies = [
  "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.56.0",
- "gix-pack 0.66.0",
- "gix-path",
- "gix-quote",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-pack 0.70.0",
+ "gix-path 0.12.0",
+ "gix-quote 0.7.1",
+ "memmap2",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -1712,12 +1973,12 @@ dependencies = [
  "clru",
  "gix-chunk 0.5.0",
  "gix-error 0.0.0",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
+ "gix-features 0.46.1",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-object 0.55.0",
- "gix-path",
- "gix-tempfile",
+ "gix-path 0.11.1",
+ "gix-tempfile 21.0.1",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -1727,19 +1988,19 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.66.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc20b54d50f64fb02281f2a6c4a24bb9356befdf4535d5a68924575fd67cd5e"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
 dependencies = [
  "clru",
- "gix-chunk 0.6.0",
- "gix-error 0.1.0",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.56.0",
- "gix-path",
- "gix-tempfile",
+ "gix-chunk 0.7.1",
+ "gix-error 0.2.3",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-tempfile 23.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -1749,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.1"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25429ee1ef792d9b653ee5de09bb525489fc8e6908334cfd5d5824269f0b7073"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -1772,6 +2033,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-pathspec"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,10 +2052,25 @@ checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
+ "gix-attributes 0.30.1",
+ "gix-config-value 0.17.1",
+ "gix-glob 0.24.0",
+ "gix-path 0.11.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes 0.33.0",
+ "gix-config-value 0.18.0",
+ "gix-glob 0.26.0",
+ "gix-path 0.12.0",
  "thiserror 2.0.18",
 ]
 
@@ -1792,8 +2080,21 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
 dependencies = [
- "gix-command",
- "gix-config-value",
+ "gix-command 0.7.1",
+ "gix-config-value 0.17.1",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041a626c64cb69e4117fcdf80da8d0e454fba3b1f420412792d191f52251aee"
+dependencies = [
+ "gix-command 0.9.0",
+ "gix-config-value 0.18.0",
  "parking_lot",
  "rustix",
  "thiserror 2.0.18",
@@ -1808,15 +2109,15 @@ dependencies = [
  "bstr",
  "gix-credentials 0.35.0",
  "gix-date 0.13.0",
- "gix-features",
- "gix-hash",
- "gix-lock",
+ "gix-features 0.46.1",
+ "gix-hash 0.22.1",
+ "gix-lock 21.0.1",
  "gix-negotiate 0.26.0",
  "gix-object 0.55.0",
  "gix-ref 0.58.0",
  "gix-refspec 0.36.0",
  "gix-revwalk 0.26.0",
- "gix-shallow",
+ "gix-shallow 0.8.1",
  "gix-trace",
  "gix-transport 0.53.0",
  "gix-utils",
@@ -1827,28 +2128,28 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.57.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13680c03e847d8f32a59cf1511dd05334d429da33f5af08891367680f15cbca"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
 dependencies = [
  "bstr",
- "gix-credentials 0.36.0",
- "gix-date 0.14.0",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-negotiate 0.27.0",
- "gix-object 0.56.0",
- "gix-ref 0.59.0",
- "gix-refspec 0.37.0",
- "gix-revwalk 0.27.0",
- "gix-shallow",
+ "gix-credentials 0.38.0",
+ "gix-date 0.15.3",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.0",
+ "gix-negotiate 0.31.0",
+ "gix-object 0.60.0",
+ "gix-ref 0.63.0",
+ "gix-refspec 0.41.0",
+ "gix-revwalk 0.31.0",
+ "gix-shallow 0.12.0",
  "gix-trace",
- "gix-transport 0.54.0",
+ "gix-transport 0.57.0",
  "gix-utils",
  "maybe-async",
+ "nonempty",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1863,19 +2164,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.3",
+ "gix-utils",
+]
+
+[[package]]
 name = "gix-ref"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
 dependencies = [
  "gix-actor 0.38.0",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
+ "gix-features 0.46.1",
+ "gix-fs 0.19.1",
+ "gix-hash 0.22.1",
+ "gix-lock 21.0.1",
  "gix-object 0.55.0",
- "gix-path",
- "gix-tempfile",
+ "gix-path 0.11.1",
+ "gix-tempfile 21.0.1",
  "gix-utils",
  "gix-validate",
  "memmap2",
@@ -1885,23 +2197,22 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92fd2e86d65efe972a5226f303ed72cfb49a8ad03740e5cc2b27c07970a5d78"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
- "gix-actor 0.39.0",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object 0.56.0",
- "gix-path",
- "gix-tempfile",
+ "gix-actor 0.41.0",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-tempfile 23.0.0",
  "gix-utils",
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1912,8 +2223,8 @@ checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
 dependencies = [
  "bstr",
  "gix-error 0.0.0",
- "gix-glob",
- "gix-hash",
+ "gix-glob 0.24.0",
+ "gix-hash 0.22.1",
  "gix-revision 0.40.0",
  "gix-validate",
  "smallvec",
@@ -1922,15 +2233,15 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.37.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40adba15f8099159d37d0a21e1cfb6602c2e49b6c05f6f8a57a47d0fb21611af"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
 dependencies = [
  "bstr",
- "gix-error 0.1.0",
- "gix-glob",
- "gix-hash",
- "gix-revision 0.41.0",
+ "gix-error 0.2.3",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-revision 0.45.0",
  "gix-validate",
  "smallvec",
  "thiserror 2.0.18",
@@ -1947,8 +2258,8 @@ dependencies = [
  "gix-commitgraph 0.32.0",
  "gix-date 0.13.0",
  "gix-error 0.0.0",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-object 0.55.0",
  "gix-revwalk 0.26.0",
  "gix-trace",
@@ -1956,20 +2267,21 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ef94c9d76de0765e429ae22a01c512c0d50459269195a90ea11099a5fc752"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-commitgraph 0.33.0",
- "gix-date 0.14.0",
- "gix-error 0.1.0",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.56.0",
- "gix-revwalk 0.27.0",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
  "gix-trace",
+ "nonempty",
 ]
 
 [[package]]
@@ -1981,8 +2293,8 @@ dependencies = [
  "gix-commitgraph 0.32.0",
  "gix-date 0.13.0",
  "gix-error 0.0.0",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-object 0.55.0",
  "smallvec",
  "thiserror 2.0.18",
@@ -1990,16 +2302,16 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07efcad1d064abdac3e79dfc6e23e05accb579559d015e944c9dcf64be95eb49"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
 dependencies = [
- "gix-commitgraph 0.33.0",
- "gix-date 0.14.0",
- "gix-error 0.1.0",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.56.0",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -2011,7 +2323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e014df75f3d7f5c98b18b45c202422da6236a1c0c0a50997c3f41e601f3ad511"
 dependencies = [
  "bitflags",
- "gix-path",
+ "gix-path 0.11.1",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+dependencies = [
+ "bitflags",
+ "gix-path 0.12.0",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -2023,8 +2347,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
 dependencies = [
  "bstr",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.22.1",
+ "gix-lock 21.0.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+dependencies = [
+ "bstr",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.0",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff 0.63.0",
+ "gix-dir",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-pathspec 0.18.0",
+ "gix-worktree 0.52.0",
+ "portable-atomic",
  "thiserror 2.0.18",
 ]
 
@@ -2036,25 +2396,25 @@ checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
 dependencies = [
  "bstr",
  "gix-config 0.51.0",
- "gix-path",
- "gix-pathspec",
+ "gix-path 0.11.1",
+ "gix-pathspec 0.15.1",
  "gix-refspec 0.36.0",
- "gix-url",
+ "gix-url 0.35.2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d38afa855046b7b9e2b85f8cdf7fbf2e449ed061dc81fa7a757abaa38bfac"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
 dependencies = [
  "bstr",
- "gix-config 0.52.0",
- "gix-path",
- "gix-pathspec",
- "gix-refspec 0.37.0",
- "gix-url",
+ "gix-config 0.56.0",
+ "gix-path 0.12.0",
+ "gix-pathspec 0.18.0",
+ "gix-refspec 0.41.0",
+ "gix-url 0.36.0",
  "thiserror 2.0.18",
 ]
 
@@ -2064,7 +2424,20 @@ version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9ab2c89fe4bfd4f1d8700aa4516534c170d8a21ae2c554167374607c2eaf16"
 dependencies = [
- "gix-fs",
+ "gix-fs 0.19.1",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+dependencies = [
+ "dashmap",
+ "gix-fs 0.21.1",
  "libc",
  "parking_lot",
  "tempfile",
@@ -2072,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-transport"
@@ -2084,32 +2457,32 @@ checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
 dependencies = [
  "base64",
  "bstr",
- "gix-command",
+ "gix-command 0.7.1",
  "gix-credentials 0.35.0",
- "gix-features",
+ "gix-features 0.46.1",
  "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
+ "gix-quote 0.6.2",
+ "gix-sec 0.13.1",
+ "gix-url 0.35.2",
  "reqwest",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.54.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9561a98f4f1cada03b565121c475c95d060998082bdb1277044fa6e11fe2aa17"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
 dependencies = [
  "base64",
  "bstr",
- "gix-command",
- "gix-credentials 0.36.0",
- "gix-features",
+ "gix-command 0.9.0",
+ "gix-credentials 0.38.0",
+ "gix-features 0.48.0",
  "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
+ "gix-quote 0.7.1",
+ "gix-sec 0.14.0",
+ "gix-url 0.36.0",
  "reqwest",
  "thiserror 2.0.18",
 ]
@@ -2123,8 +2496,8 @@ dependencies = [
  "bitflags",
  "gix-commitgraph 0.32.0",
  "gix-date 0.13.0",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-object 0.55.0",
  "gix-revwalk 0.26.0",
  "smallvec",
@@ -2133,17 +2506,17 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.53.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdd399f8527f643f8d4fd8de6ec3b6e2c3c826b758b68e90f28275af2e7b33a"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
 dependencies = [
  "bitflags",
- "gix-commitgraph 0.33.0",
- "gix-date 0.14.0",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.56.0",
- "gix-revwalk 0.27.0",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.3",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -2155,26 +2528,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
 dependencies = [
  "bstr",
- "gix-path",
+ "gix-path 0.11.1",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+dependencies = [
+ "bstr",
+ "gix-path 0.12.0",
  "percent-encoding",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
 dependencies = [
+ "bstr",
  "fastrand",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
 dependencies = [
  "bstr",
 ]
@@ -2186,32 +2572,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
+ "gix-attributes 0.30.1",
+ "gix-fs 0.19.1",
+ "gix-glob 0.24.0",
+ "gix-hash 0.22.1",
+ "gix-ignore 0.19.0",
  "gix-index 0.46.0",
  "gix-object 0.55.0",
- "gix-path",
+ "gix-path 0.11.1",
  "gix-validate",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93381c5cd37fa208e3f454433425985ea02725369fb33a79ff4ecf7c279f2f98"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index 0.47.0",
- "gix-object 0.56.0",
- "gix-path",
+ "gix-attributes 0.33.0",
+ "gix-fs 0.21.1",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
  "gix-validate",
 ]
 
@@ -2222,15 +2608,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.46.1",
  "gix-filter 0.25.0",
- "gix-fs",
+ "gix-fs 0.19.1",
  "gix-index 0.46.0",
  "gix-object 0.55.0",
- "gix-path",
+ "gix-path 0.11.1",
  "gix-worktree 0.47.0",
  "io-close",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-worktree 0.52.0",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes 0.33.0",
+ "gix-error 0.2.3",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-path 0.12.0",
+ "gix-traverse 0.57.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2716,7 +3138,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2983,12 +3405,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3282,7 +3710,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3539,7 +3967,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3596,7 +4024,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3921,7 +4349,7 @@ dependencies = [
  "either",
  "font-awesome-as-a-crate",
  "futures-util",
- "gix 0.79.0",
+ "gix 0.83.0",
  "grass",
  "indexmap 2.13.0",
  "lru_time_cache",
@@ -4010,7 +4438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4103,7 +4531,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4759,7 +5187,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4847,15 +5275,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4887,28 +5306,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4924,12 +5326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,12 +5336,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4960,22 +5350,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4990,12 +5368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,12 +5378,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5026,12 +5392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5042,12 +5402,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ actix-web = { version = "4", default-features = false, features = ["macros", "co
 actix-web-lab = { version = "0.26", default-features = false }
 anyhow = "1"
 crates-index = { version = "3", default-features = false, features = ["git", "git-https-reqwest"] }
-# to be kept in sync with the version used by `crates-index`
-gix = { version = "0.79", default-features = false }
 derive_more = { version = "2", features = ["display", "error", "from"] }
 dotenvy = "0.15"
 either = "1.12"
 font-awesome-as-a-crate = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+# to be kept in sync with the version used by `crates-index`
+gix = { version = "0.83", default-features = false }
 indexmap = { version = "2", features = ["serde"] }
 lru_time_cache = "0.11"
 maud = "0.27"


### PR DESCRIPTION
## Why

- Move `gix` to the patched `0.83.0` line for [GHSA-f26g-jm89-4g65](https://github.com/advisories/GHSA-f26g-jm89-4g65), which affects `gix` versions before `0.83.0`.
- deps.rs is unlikely to exercise the vulnerable submodule update path directly, but staying on the patched `gix` release is still valuable.

## What

- Update the direct `gix` dependency requirement from `0.79` to `0.83`.
- Refresh `Cargo.lock`, including `crates-index` `3.14.0`, `gix` `0.83.0`, and the related `gix` dependency graph.

## Validation

- `cargo check`

## Risks

- This is a dependency update with possible behavior changes in the `gix` stack, but no source changes were needed.
